### PR TITLE
Avatar 컴포넌트 초기 생성 및 storybook 추가

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Avatar from './Avatar';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Component/Avatar',
+  component: Avatar,
+  argTypes: {
+    size: {
+      control: {
+        type: 'select',
+        options: ['small', 'medium', 'large']
+      }
+    },
+    isOnline: {
+      control: {
+        type: 'select',
+        options: ['none', 'online', 'offline']
+      }
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Default: Story = {
+  args: {
+    isOnline: 'online',
+    size: 'medium',
+    src: 'https://flowbite.com/docs/images/people/profile-picture-5.jpg'
+  },
+  render: (args) => <Avatar {...args} />
+};

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,0 +1,45 @@
+import { ImgHTMLAttributes } from 'react';
+
+interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
+  size: 'small' | 'medium' | 'large';
+  src: string;
+  alt?: string;
+  isOnline?: 'none' | 'online' | 'offline';
+}
+
+const sizesConfig = {
+  small: 'w-10 h-10',
+  medium: 'w-12 h-12',
+  large: 'w-14 h-14'
+};
+
+const onlineConfig = {
+  online: 'bg-primary',
+  offline: 'bg-gray-400'
+};
+
+const Avatar = ({
+  size,
+  src,
+  alt = '',
+  isOnline = 'none',
+  ...props
+}: AvatarProps) => {
+  return (
+    <div className="relative inline-block">
+      <img
+        src={src}
+        alt={alt}
+        {...props}
+        className={`${sizesConfig[size]} rounded-full`}
+      />
+      {isOnline !== 'none' && (
+        <div
+          className={`absolute left-0 top-0 h-3 w-3 rounded-full ${onlineConfig[isOnline]}`}
+        />
+      )}
+    </div>
+  );
+};
+
+export default Avatar;

--- a/src/components/Avatar/index.ts
+++ b/src/components/Avatar/index.ts
@@ -1,0 +1,1 @@
+export { default as Avatar } from './Avatar';


### PR DESCRIPTION
## 간단한 내용 설명
Avatar 컴포넌트 초기 버전 생성 및 storybook 설정을 추가했습니다.

## 구현 내용
prop으로 size, src, alt, isOnline을 입력받습니다.
size: ['small', 'medium', 'large'],
isOnline: ['none', 'online', 'offline'] =>  none: badge없음, online: badge색깔 적용, offline: badge 색깔 회색
alt: string
src: string

## 이슈 번호

- close #36 

<!--## 테스트 계획 또는 완료 사항-->
