### PR TITLE
Card 컴포넌트 추가(Card, CardTitle)

### DIFF
--- a/src/components/Cards/Card.stories.tsx
+++ b/src/components/Cards/Card.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Card from './Card';
+import CardTitle from './CardTitle';
+import { Image } from '../Image';
+
+const meta: Meta<typeof Card> = {
+  title: 'Component/Card',
+  component: Card,
+  argTypes: {
+    title: {
+      type: 'string'
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const ExampleCard: Story = {
+  args: {
+    title: 'title'
+  },
+  render: (args) => (
+    <Card>
+      <Image
+        className="h-40 w-40"
+        src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
+      />
+      <CardTitle>{args.title}</CardTitle>
+    </Card>
+  )
+};

--- a/src/components/Cards/Card.tsx
+++ b/src/components/Cards/Card.tsx
@@ -1,0 +1,27 @@
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+  direction?: 'row' | 'col';
+}
+
+const directionConfig = {
+  row: 'flex-row',
+  col: 'flex-col'
+};
+
+const Card = ({
+  children,
+  direction = 'col',
+  className,
+  ...props
+}: CardProps) => {
+  return (
+    <div
+      className={`flex ${directionConfig[direction]} h-fit w-fit gap-2 rounded-md border p-3 shadow-md ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Card;

--- a/src/components/Cards/CardTitle.tsx
+++ b/src/components/Cards/CardTitle.tsx
@@ -1,0 +1,9 @@
+interface CardHeaderProps {
+  children: React.ReactNode;
+}
+
+const CardTitle = ({ children }: CardHeaderProps) => {
+  return <h1 className="font-medium">{children}</h1>;
+};
+
+export default CardTitle;

--- a/src/components/Cards/CardTitle.tsx
+++ b/src/components/Cards/CardTitle.tsx
@@ -1,8 +1,8 @@
-interface CardHeaderProps {
+interface CardTitleProps {
   children: React.ReactNode;
 }
 
-const CardTitle = ({ children }: CardHeaderProps) => {
+const CardTitle = ({ children }: CardTitleProps) => {
   return <h1 className="font-medium">{children}</h1>;
 };
 

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Image from './Image';
+
+const meta: Meta<typeof Image> = {
+  title: 'Component/Image',
+  component: Image,
+  argTypes: {
+    title: {
+      src: 'string'
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof Image>;
+
+export const Default: Story = {
+  args: {
+    src: 'https://flowbite.com/docs/images/people/profile-picture-5.jpg'
+  },
+  render: (args) => <Image {...args} />
+};

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,0 +1,12 @@
+import { ImgHTMLAttributes } from 'react';
+
+interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  src: string;
+  className?: string;
+}
+
+const Image = ({ src, className, ...props }: ImageProps) => {
+  return <img src={src} {...props} className={`rounded-md ${className}`} />;
+};
+
+export default Image;

--- a/src/components/Image/index.ts
+++ b/src/components/Image/index.ts
@@ -1,0 +1,1 @@
+export { default as Image } from './Image';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+  plugins: [react()]
+});


### PR DESCRIPTION
## 간단한 내용 설명

- [x] 카드 컴포넌트 구현
- [x] 카드 컴포넌트 스토리 추가

## 구현 내용
Card 컴포넌트 속에 필요한 아이템들을 children으로 넣어서 하나의 card를 만들 수 있도록 컴포넌트를 추가했습니다.

<!-- ## 스크린샷 -->

<!--## 장애물 -->

## PR 포인트<!--리뷰어가 집중했으면 하는 부분 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

## 궁금한 점

## 이슈 번호
- close #38

<!--## 테스트 계획 또는 완료 사항-->
