### PR TITLE
useAuth, useUser hooks를 통해 사용자 상태 로컬 스토리지 저장 및 리액트 쿼리에 캐싱

### DIFF
--- a/src/api/snsApiClient.ts
+++ b/src/api/snsApiClient.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getStoredUser } from '~/hooks/userStorage';
 
 const { VITE_API_END_POINT } = import.meta.env;
 
@@ -7,10 +8,10 @@ export const snsApiClient = axios.create({
 });
 
 snsApiClient.interceptors.request.use((config) => {
-  const token = window.localStorage.getItem('token');
+  const user = getStoredUser();
 
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
+  if (user) {
+    config.headers.Authorization = `Bearer ${user.token}`;
   }
 
   return config;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,49 @@
+import { snsApiClient } from '~/api';
+import useUser from './useUser';
+
+interface SignIn {
+  email: string;
+  password: string;
+}
+
+interface SignUp extends SignIn {
+  fullName: string;
+}
+
+function useAuth() {
+  const { clearUser, updateUser } = useUser();
+
+  async function authServerCall(
+    urlEndpoint: string,
+    authInfo: SignIn | SignUp
+  ) {
+    try {
+      const { data, status } = await snsApiClient.post(urlEndpoint, authInfo);
+
+      if (status === 400) {
+        console.log('Unauthorized');
+        return;
+      }
+
+      if ('user' in data && 'token' in data) {
+        updateUser(data);
+      }
+    } catch {}
+  }
+
+  async function signIn({ email, password }: SignIn) {
+    authServerCall('/login', { email, password });
+  }
+
+  async function signUp({ email, fullName, password }: SignUp) {
+    authServerCall('/signup', { email, fullName, password });
+  }
+
+  function signOut() {
+    clearUser();
+  }
+
+  return { signIn, signUp, signOut };
+}
+
+export default useAuth;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,0 +1,44 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { clearStoredUser, getStoredUser, setStoredUser } from './userStorage';
+import { snsApiClient } from '~/api';
+
+async function getUser(user: any) {
+  if (!user) return null;
+
+  const { data } = await snsApiClient.get('/auth-user', {
+    headers: {
+      Authorization: `Bearer ${user.token}`
+    }
+  });
+  return { user: data, token: user.token };
+}
+
+function useUser() {
+  const queryClient = useQueryClient();
+
+  const { data: user } = useQuery({
+    queryKey: ['user'],
+    queryFn: (): any => getUser(user),
+    initialData: getStoredUser(),
+    onSuccess: (received) => {
+      if (received) {
+        setStoredUser(received);
+      } else {
+        clearStoredUser();
+      }
+    }
+  });
+
+  function updateUser(newUser: any) {
+    queryClient.setQueryData(['user'], newUser);
+  }
+
+  function clearUser() {
+    queryClient.setQueryData(['user'], null);
+    clearStoredUser();
+  }
+
+  return { user, updateUser, clearUser };
+}
+
+export default useUser;

--- a/src/hooks/userStorage.ts
+++ b/src/hooks/userStorage.ts
@@ -1,0 +1,16 @@
+const USER_LOCAL_STORAGE_KEY = 'user';
+
+function getStoredUser() {
+  const storedUser = window.localStorage.getItem(USER_LOCAL_STORAGE_KEY);
+  return storedUser ? JSON.parse(storedUser) : null;
+}
+
+function setStoredUser(user: any) {
+  localStorage.setItem(USER_LOCAL_STORAGE_KEY, JSON.stringify(user));
+}
+
+function clearStoredUser() {
+  localStorage.removeItem(USER_LOCAL_STORAGE_KEY);
+}
+
+export { getStoredUser, setStoredUser, clearStoredUser };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { Button, Input } from '~/components';
 import { useForm } from '~/hooks';
-import { channelService, userService } from '~/services';
+import useAuth from '~/hooks/useAuth';
+import { channelService } from '~/services';
 
 const HomePage = () => {
   const [loginEmail, handleChangeLoginEmail] = useForm();
@@ -9,27 +10,13 @@ const HomePage = () => {
   const [email, handleChangeEmail] = useForm();
   const [fullName, handleFullName] = useForm();
   const [password, handleChangePassword] = useForm();
-
-  const userMutation = useMutation({
-    mutationFn: userService.signIn,
-    onSuccess({ data }) {
-      window.localStorage.setItem('token', data.token);
-    }
-  });
+  const { signIn, signUp, signOut } = useAuth();
 
   const channelMutation = useMutation({ mutationFn: channelService.create });
 
-  const signupMutation = useMutation({
-    mutationFn: userService.signUp,
-    onSuccess({ data }) {
-      console.log(data);
-    }
-  });
-
-  const handleLogin = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSignIn = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(loginEmail, loginPassword);
-    userMutation.mutate({ email: loginEmail, password: loginPassword });
+    signIn({ email: loginEmail, password: loginPassword });
   };
 
   const handleCreateChannel = () => {
@@ -40,17 +27,26 @@ const HomePage = () => {
     });
   };
 
-  const handleSignup = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSignUp = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    signupMutation.mutate({ email, fullName, password });
+    signUp({
+      email,
+      fullName,
+      password
+    });
+  };
+
+  const handleSignOut = () => {
+    signOut();
   };
 
   return (
     <div>
       <h1>Home page</h1>
+      <button onClick={handleSignOut}>logout</button>
       <div>
         <h2>임시 로그인</h2>
-        <form onSubmit={handleLogin}>
+        <form onSubmit={handleSignIn}>
           <Input
             placeholder="이메일 입력"
             type="email"
@@ -69,7 +65,7 @@ const HomePage = () => {
 
       <div>
         <h2>임시 회원가입</h2>
-        <form onSubmit={handleSignup}>
+        <form onSubmit={handleSignUp}>
           <Input
             placeholder="이메일 입력"
             type="email"


### PR DESCRIPTION
## 간단한 내용 설명

useAuth, useUser 라는 커스텀 hooks를 만들어서 사용자 상태를 로컬 스토리지에 저장하고 리액트 쿼리에 캐싱합니다.
[참고 문서](https://wonsss.github.io/library/react-query/#useauth%EC%97%90%EC%84%9C-query-cache-%EA%B0%92-%EC%84%A4%EC%A0%95)

## 구현 내용

- useAuth
  - 반환값: `return { signIn, signUp, signOut };`
  - signIn, signUp, signOut 함수를 통해 로그인, 로그아웃, 회원가입을 담당
- useUser
  - 반환값: `return { user, updateUser, clearUser };`
  - 회원가입, 로그인, 로그아웃 등 사용자 상태에 변경이 생길 시 로컬 스토리지와 리액트 쿼리의 사용자 데이터 변경을 담당
  - **user**
    - user의 정보와 토큰 값이 담겨있는 리액트 쿼리 값
      - user.user: user 정보(fullName, email, 사용자 id 등)
      - user.token: 사용자 JWT token

## 궁금한 점

api로 반환되는 데이터 타입에 대한 정의가 필요한 것 같네요!
아까 User 타입이 필요하다고 했는데 확인해보니 User 타입 속에 서로 타른 타입들이 서로 의존하고 있습니다(Post, Like 등)
types 폴더에 ApiResponseType 이라는 파일로 만들어서 api 반환 타입들을 정리해도 좋을 것 같습니다.

## 이슈 번호

- close #62

<!--## 테스트 계획 또는 완료 사항-->
