### PR TITLE
특정 포스트 상세 api 작업

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,2 +1,3 @@
 export { default as channelService } from './channelService';
 export { default as userService } from './userService';
+export { default as postService } from './postService';

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -1,0 +1,25 @@
+import { snsApiClient } from '~/api';
+
+interface Create {
+  title: string;
+  content: string;
+  image?: BinaryType;
+  channelId: string;
+}
+
+const postService = {
+  async create({ title, content, image, channelId }: Create) {
+    const customPost = JSON.stringify({ title, content });
+
+    return await snsApiClient.post('/posts/create', {
+      title: customPost,
+      image,
+      channelId
+    });
+  },
+  async get(postId: string) {
+    return await snsApiClient.get(`/posts/${postId}`);
+  }
+};
+
+export default postService;

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -7,6 +7,15 @@ interface Create {
   channelId: string;
 }
 
+interface Edit {
+  postId: string;
+  title: string;
+  content: string;
+  image: BinaryType | null;
+  imageToDeletePublicId?: string;
+  channelId: string;
+}
+
 const postService = {
   async create({ title, content, image, channelId }: Create) {
     const customPost = JSON.stringify({ title, content });
@@ -19,6 +28,24 @@ const postService = {
   },
   async get(postId: string) {
     return await snsApiClient.get(`/posts/${postId}`);
+  },
+  async edit({
+    postId,
+    title,
+    content,
+    image,
+    imageToDeletePublicId,
+    channelId
+  }: Edit) {
+    const customPost = JSON.stringify({ title, content });
+
+    return await snsApiClient.put('/posts/update', {
+      postId,
+      title: customPost,
+      image,
+      imageToDeletePublicId,
+      channelId
+    });
   }
 };
 

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -46,6 +46,9 @@ const postService = {
       imageToDeletePublicId,
       channelId
     });
+  },
+  async delete(id: string) {
+    return await snsApiClient.delete('/posts/delete', { data: { id } });
   }
 };
 

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -49,6 +49,12 @@ const postService = {
   },
   async delete(id: string) {
     return await snsApiClient.delete('/posts/delete', { data: { id } });
+  },
+  async like(postId: string) {
+    return await snsApiClient.post('/likes/create', { postId });
+  },
+  async unlike(id: string) {
+    return await snsApiClient.delete('/likes/delete', { data: { id } });
   }
 };
 


### PR DESCRIPTION
## 간단한 내용 설명

특정 포스트 상세 api 작업을 진행했습니다.

## 구현 내용

`postService`에 `create` 외 다른 api 서비스 메서드(댓글 제외)들도 구현했습니다.

-  특정 포스트 상세 보기 api
-  내가 작성한 포스트 수정하기 api
-  내가 작성한 포스트 삭제하기 api
-  특정 포스트 좋아요 api
-  특정 포스트 좋아요 취소 api

## 스크린샷

<img src='https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/97094709/3bd162f0-3b44-47c8-ad31-2bf8a2a46a64' height='200' />
<img src='https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/97094709/6a63d353-594f-4316-aa75-02336818a6c4'  height='200' />

<br>
<br>

테스트를 진행해봤습니다. 
이때까지 사용했던 `useMutation`이나 `useQuery`로 적용하면 잘 동작하는 것을 확인할 수 있습니다.

<!--## 장애물 -->


## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

### 좋아요 기능

좋아요를 클릭하는 횟수가 제한되어 있지 않아서 무한으로 누를 수 있을 텐데, 이걸 막을 건지 냅둘 건지 정하면 좋겠네요.
좋아요마다 id 값이 있어서 저희 선택에 따라 결과가 달라질 것 같습니다.

아마 보통은 한 번 클릭했을 때는 눌렸다는(active) 아이콘 표시가 보이고 막아지는데, 이 부분을 처리해야 합니다!

## 궁금한 점

- `postId` vs `id` 둘 중 어떤 걸 매개변수 이름으로 정해야 할지 몰라서 일단 `requestBody` 값과 동일하게 적용했습니다.
- `edit` vs `update` 이것도 갈리는 것 같아서 정하면 좋겠네요! 저번에 얘기가 나온 것 같은데 확실하게 정하지 않은 것 같아요.
- `customPost = JSON.stringify({ title, content })` 이 부분이 `create`와 `edit` 부분에서 중복되는데, 문제가 될까요?
- 좋아요나 수정을 눌렀을 때, 바로 `useQuery`로 만든 쿼리 데이터가 업데이트 되고 렌더링해서 보여지게 하는 방법을 아직 잘 모르겠네요.. 더 찾아봐야겠습니다.

## 이슈 번호

- close #64 

<!--## 테스트 계획 또는 완료 사항-->
