### PR TITLE
React query 리팩토링 작업

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,12 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
 import { Button, Input } from '~/components';
 import { useForm } from '~/hooks';
-import { channelService, postService, userService } from '~/services';
+import {
+  useCreateChannel,
+  useCreatePost,
+  useGetChannels,
+  useSignIn,
+  useSignUp
+} from '~/services';
 
 const HomePage = () => {
   const [loginEmail, handleChangeLoginEmail] = useForm();
@@ -12,46 +17,31 @@ const HomePage = () => {
   const [title, handleChangeTitle] = useForm();
   const [content, handleChangeContent] = useForm();
 
-  const { data: channelsQuery } = useQuery({
-    queryKey: ['getChannels'],
-    queryFn: channelService.getChannels
-  });
+  const { data: channels } = useGetChannels();
+  console.log(channels);
 
-  const userMutation = useMutation({
-    mutationFn: userService.signIn,
-    onSuccess({ data }) {
-      window.localStorage.setItem('token', data.token);
-    }
-  });
-
-  const channelMutation = useMutation({ mutationFn: channelService.create });
-
-  const signupMutation = useMutation({
-    mutationFn: userService.signUp,
-    onSuccess({ data }) {
-      console.log(data);
-    }
-  });
-
-  const postCreateMutation = useMutation({ mutationFn: postService.create });
+  const { mutate: createChannel } = useCreateChannel();
+  const { mutate: createPost } = useCreatePost();
+  const { mutate: signIn } = useSignIn();
+  const { mutate: signUp } = useSignUp();
 
   const handleSignIn = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     console.log(loginEmail, loginPassword);
-    userMutation.mutate({ email: loginEmail, password: loginPassword });
+    signIn({ email: loginEmail, password: loginPassword });
   };
 
   const handleCreateChannel = () => {
-    channelMutation.mutate({
+    createChannel({
       authRequired: true,
-      description: '테스트 채널입니다.',
-      name: '테스트 채널'
+      description: '쿼리 테스트입니다.',
+      name: 'query test'
     });
   };
 
   const handleSignup = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    signupMutation.mutate({ email, fullName, password });
+    signUp({ email, fullName, password });
   };
 
   const handleCreatePost = (e: React.FormEvent<HTMLFormElement>) => {
@@ -59,7 +49,7 @@ const HomePage = () => {
 
     const TEMP_CHANNEL_ID = '64f843de36f4f3110a635033';
 
-    postCreateMutation.mutate({ title, content, channelId: TEMP_CHANNEL_ID });
+    createPost({ title, content, channelId: TEMP_CHANNEL_ID });
   };
 
   return (

--- a/src/services/channelService.ts
+++ b/src/services/channelService.ts
@@ -1,3 +1,4 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { snsApiClient } from '~/api';
 
 interface Create {
@@ -6,18 +7,24 @@ interface Create {
   name: string;
 }
 
-const channelService = {
-  async create({ authRequired, description, name }: Create) {
-    return await snsApiClient.post('/channels/create', {
-      authRequired,
-      description,
-      name
-    });
-  },
+const getChannels = async () => {
+  const response = await snsApiClient.get('/channels');
 
-  async getChannels() {
-    return await snsApiClient.get('/channels');
-  }
+  return response.data;
 };
 
-export default channelService;
+const createChannel = async ({ authRequired, description, name }: Create) => {
+  return await snsApiClient.post('/channels/create', {
+    authRequired,
+    description,
+    name
+  });
+};
+
+export const useGetChannels = () => {
+  return useQuery({ queryKey: ['getChannels'], queryFn: getChannels });
+};
+
+export const useCreateChannel = () => {
+  return useMutation({ mutationFn: createChannel });
+};

--- a/src/services/channelService.ts
+++ b/src/services/channelService.ts
@@ -7,6 +7,10 @@ interface Create {
   name: string;
 }
 
+const channelKeys = {
+  all: ['channels'] as const
+};
+
 const getChannels = async () => {
   const response = await snsApiClient.get('/channels');
 
@@ -22,7 +26,7 @@ const createChannel = async ({ authRequired, description, name }: Create) => {
 };
 
 export const useGetChannels = () => {
-  return useQuery({ queryKey: ['getChannels'], queryFn: getChannels });
+  return useQuery({ queryKey: channelKeys.all, queryFn: getChannels });
 };
 
 export const useCreateChannel = () => {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,3 @@
-export { default as channelService } from './channelService';
-export { default as userService } from './userService';
-export { default as postService } from './postService';
+export * from './channelService';
+export * from './postService';
+export * from './userService';

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -1,22 +1,23 @@
+import { useMutation } from '@tanstack/react-query';
 import { snsApiClient } from '~/api';
 
-interface Create {
+interface CreatePost {
   title: string;
   content: string;
   image?: BinaryType;
   channelId: string;
 }
 
-const postService = {
-  async create({ title, content, image, channelId }: Create) {
-    const customPost = JSON.stringify({ title, content });
+const createPost = async ({ title, content, image, channelId }: CreatePost) => {
+  const customPost = JSON.stringify({ title, content });
 
-    return await snsApiClient.post('/posts/create', {
-      title: customPost,
-      image,
-      channelId
-    });
-  }
+  return await snsApiClient.post('/posts/create', {
+    title: customPost,
+    image,
+    channelId
+  });
 };
 
-export default postService;
+export const useCreatePost = () => {
+  return useMutation({ mutationFn: createPost });
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { snsApiClient } from '~/api';
 
 interface SignIn {
@@ -11,14 +12,23 @@ interface SignUp {
   password: string;
 }
 
-const userService = {
-  async signIn({ email, password }: SignIn) {
-    return await snsApiClient.post('/login', { email, password });
-  },
-
-  async signUp({ email, fullName, password }: SignUp) {
-    return await snsApiClient.post('/signup', { email, fullName, password });
-  }
+const signIn = async ({ email, password }: SignIn) => {
+  return await snsApiClient.post('/login', { email, password });
 };
 
-export default userService;
+const signUp = async ({ email, fullName, password }: SignUp) => {
+  return await snsApiClient.post('/signup', { email, fullName, password });
+};
+
+export const useSignIn = () => {
+  return useMutation({
+    mutationFn: signIn,
+    onSuccess: ({ data }) => {
+      window.localStorage.setItem('token', data.token);
+    }
+  });
+};
+
+export const useSignUp = () => {
+  return useMutation({ mutationFn: signUp });
+};


### PR DESCRIPTION
## 간단한 내용 설명

React Query 관련 리팩토링 작업을 진행했습니다.
사용하는 쪽에서 간단히 훅만 불러오는 형태로 변경했습니다.

## 구현 내용

앞으로 이러한 형태로 사용될 것 같습니다.

```tsx
const { data: channels } = useGetChannels();

const { mutate: createChannel } = useCreateChannel();
const { mutate: createPost } = useCreatePost();
const { mutate: signIn } = useSignIn();
const { mutate: signUp } = useSignUp();
```

<!-- ## 스크린샷 -->

<!--## 장애물 -->

## PR 포인트<!--리뷰어가 집중했으면 하는 부분 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

- 점점 React Query에 대해 알아갈수록 `hook`에 가까운 형태로 쓰면 좋은 것 같아서 추후에 폴더 위치를 변경하면 어떨까 싶습니다.
- 관련 내용 위키에 적어두었습니다. 참고 부탁드립니다..! [React Query](https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/wiki/%EA%B8%B0%EC%88%A0-%EC%8A%A4%ED%83%9D#-react-query)

## 궁금한 점

## 이슈 번호

- close #67 

<!--## 테스트 계획 또는 완료 사항-->
