### PR TITLE
게시물 댓글 관련 작업

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,11 @@
 import { Button, Card, Image, Input, Badge, Avatar } from '~/components';
 import { useForm, useAuth } from '~/hooks';
-import { useCreateChannel, useCreatePost, useGetChannels } from '~/services';
+import {
+  useCreateChannel,
+  useCreateComment,
+  useCreatePost,
+  useGetChannels
+} from '~/services';
 
 const HomePage = () => {
   const [loginEmail, handleChangeLoginEmail] = useForm();
@@ -10,11 +15,15 @@ const HomePage = () => {
   const [password, handleChangePassword] = useForm();
   const [title, handleChangeTitle] = useForm();
   const [content, handleChangeContent] = useForm();
+  const [comment, handleChangeComment] = useForm();
 
   const { signIn, signUp, signOut } = useAuth();
+
   const { data: channels } = useGetChannels();
+
   const { mutate: createChannel } = useCreateChannel();
   const { mutate: createPost } = useCreatePost();
+  const { mutate: createComment } = useCreateComment();
 
   const handleCreateChannel = () => {
     createChannel({
@@ -30,6 +39,15 @@ const HomePage = () => {
     const TEMP_CHANNEL_ID = '64f843de36f4f3110a635033';
 
     createPost({ title, content, channelId: TEMP_CHANNEL_ID });
+  };
+
+  const handleCreateComment = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const TEST_CHANNEL_ID = '64f6f7a236f4f3110a634be3';
+    const TEST_CHANNEL_POST_ID = '64fdb00136f4f3110a635623';
+
+    createComment({ comment, postId: TEST_CHANNEL_POST_ID });
   };
 
   const handleSignIn = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -121,6 +139,15 @@ const HomePage = () => {
           <input placeholder="콘텐츠" onChange={handleChangeContent} />
 
           <button>게시물 생성 버튼</button>
+        </form>
+      </div>
+
+      <div className="border-2">
+        <h2>테스트 채널 - 특정 게시물에 댓글을 추가해봅니다.</h2>
+
+        <form onSubmit={handleCreateComment}>
+          <Input placeholder="댓글 내용" onChange={handleChangeComment} />
+          <Button>댓글 생성 버튼</Button>
         </form>
       </div>
     </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -4,7 +4,8 @@ import {
   useCreateChannel,
   useCreateComment,
   useCreatePost,
-  useGetChannels
+  useGetChannels,
+  useRemoveComment
 } from '~/services';
 
 const HomePage = () => {
@@ -24,6 +25,7 @@ const HomePage = () => {
   const { mutate: createChannel } = useCreateChannel();
   const { mutate: createPost } = useCreatePost();
   const { mutate: createComment } = useCreateComment();
+  const { mutate: removeComment } = useRemoveComment();
 
   const handleCreateChannel = () => {
     createChannel({
@@ -48,6 +50,11 @@ const HomePage = () => {
     const TEST_CHANNEL_POST_ID = '64fdb00136f4f3110a635623';
 
     createComment({ comment, postId: TEST_CHANNEL_POST_ID });
+  };
+
+  const handleDeleteComment = () => {
+    const TEMP_COMMENT_ID = '65000b586a4b91143d4f9c1e';
+    removeComment({ commentId: TEMP_COMMENT_ID });
   };
 
   const handleSignIn = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -149,6 +156,13 @@ const HomePage = () => {
           <Input placeholder="댓글 내용" onChange={handleChangeComment} />
           <Button>댓글 생성 버튼</Button>
         </form>
+      </div>
+
+      <div className="border-2">
+        <h2>내가 작성한 댓글을 삭제해봅니다.</h2>
+        <Button onClick={handleDeleteComment}>
+          댓글 ID를 받아서 댓글을 삭제하는 버튼
+        </Button>
       </div>
     </div>
   );

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -6,10 +6,24 @@ interface CreateComment {
   postId: string;
 }
 
+interface RemoveComment {
+  commentId: string;
+}
+
 const createComment = async ({ comment, postId }: CreateComment) => {
   return await snsApiClient.post('/comments/create', { comment, postId });
 };
 
+const removeComment = async ({ commentId }: RemoveComment) => {
+  return await snsApiClient.delete('/comments/delete', {
+    data: { id: commentId }
+  });
+};
+
 export const useCreateComment = () => {
   return useMutation({ mutationFn: createComment });
+};
+
+export const useRemoveComment = () => {
+  return useMutation({ mutationFn: removeComment });
 };

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { snsApiClient } from '~/api';
+
+interface CreateComment {
+  comment: string;
+  postId: string;
+}
+
+const createComment = async ({ comment, postId }: CreateComment) => {
+  return await snsApiClient.post('/comments/create', { comment, postId });
+};
+
+export const useCreateComment = () => {
+  return useMutation({ mutationFn: createComment });
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from './channelService';
+export * from './commentService';
 export * from './postService';
 export * from './userService';


### PR DESCRIPTION
## 간단한 내용 설명

게시물 댓글과 관련된 작업을 진행했습니다.

- 채널 내 특정 게시물에 댓글 생성
- 내가 작성한 댓글 삭제

## 구현 내용

`homepage` 내 아래 부분에서 테스트하실 수 있습니다.

<img width="866" alt="스크린샷 2023-09-12 오후 4 18 54" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/79239852/67043321-1468-4142-bb97-3215014ba70e">

댓글 생성 시에는 임시로 테스트 채널 id, 테스트 채널 내 게시물 id를 고정시켰습니다.

- `TEST_CHANNEL_ID = '64f6f7a236f4f3110a634be3'`
- `TEST_CHANNEL_POST_ID = '64fdb00136f4f3110a635623'`

생성된 댓글은 특정 채널의 포스트 목록 api에서 확인하실 수 있습니다.

- 특정 채널의 포스트 목록: /posts/channel/64f6f7a236f4f3110a634be3

삭제하실 때에도 추가된 댓글 id를 `handleDeleteComment` 함수 내 `TEMP_COMMENT_ID` 변수 내에 넣고 버튼을 클릭하면 됩니다.
확인 api는 특정 채널의 포스트 목록 api와 같습니다.

- 특정 채널의 포스트 목록: /posts/channel/64f6f7a236f4f3110a634be3

<!-- ## 스크린샷 -->

<!--## 장애물 -->

## PR 포인트<!--리뷰어가 집중했으면 하는 부분 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

작업하면서 로그인 과정에서 에러를 겪었습니다.
원인을 파악하려고 이것저것 만지는 과정에서 해결이 되었는데 정확한 원인을 파악하지는 못했네요.. 😇
아마 추후에 인증/인가 과정을 면밀히 살펴볼 필요가 있을 것 같습니다.

댓글 삭제에서 `DELETE` 메서드가 사용됩니다.
문서 요구 사항에서는 Requst Body가 필요한데 `axios`에서 `POST` 메서드와 달리 `DELETE` 메서드는 데이터 부분이 없습니다.

[axios-api](https://axios-http.com/kr/docs/api_intro)

```
axios.post(url[, data[, config]]) // data 존재
axios.delete(url[, config]) // data 없음
```

이를 해결하기 위해 `config`에 있는 `data`에 넘겨주는 방식으로 하면 됩니다.
아마 다른 `DELETE` 메서드 부분에서 `Request Body`가 있는 부분은 이와 같은 방식으로 하면 될 것 같네요.

[요청 Config](https://axios-http.com/kr/docs/req_config)

```ts
const removeComment = async ({ commentId }: RemoveComment) => {
  return await snsApiClient.delete('/comments/delete', {
    data: { id: commentId }
  });
};
```


## 궁금한 점

## 이슈 번호

- close #76 

<!--## 테스트 계획 또는 완료 사항-->
