### PR TITLE
전체 너비 768px로 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
 <!doctype html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hon Kok</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Hon Kok</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -152,8 +152,8 @@ const MOCK_POST = [
 
 const HomePage = () => {
   return (
-    <div className="relative h-full overflow-x-hidden bg-gray-100">
-      <div className="h-[14.625rem] bg-main-lighten p-[1.5rem]">
+    <div className="relative h-full bg-gray-100">
+      <div className="h-[14.625rem] bg-main-lighten p-6">
         <div className="flex">
           <div className="grow">
             <p className="text-[0.9375rem]">이 시각</p>
@@ -163,7 +163,7 @@ const HomePage = () => {
             <span className="rounded-[1.25rem] bg-white p-1 px-2 text-[0.625rem] text-sub-red">
               HOT
             </span>
-            <p className="mt-[0.7rem] text-[0.75rem] text-gray-100">
+            <p className="mt-[0.7rem] text-xs text-gray-100">
               사람들이 가장 활발하게
               <br />
               이용하는 채널을 확인해보세요!
@@ -173,31 +173,33 @@ const HomePage = () => {
         </div>
       </div>
 
-      <ul className="absolute left-5 top-48 flex w-full gap-3 overflow-x-auto pr-7 ">
-        {MOCK_CHANNEL.map(({ id, channelName, updatedAt, decription }) => (
-          <li
-            key={id}
-            className="relative w-52 flex-shrink-0 cursor-pointer rounded-[0.625rem] bg-white p-4 shadow-sm"
-          >
-            <div className="flex gap-2">
-              <span className="rounded-[1.25rem] bg-active-lightest p-1 px-2 text-[0.625rem] text-active-darken">
-                {channelName}
-              </span>
-              <span className="rounded-[0.625rem] border border-gray-200 p-1 px-2 text-[0.5625rem] text-gray-400">
-                {updatedAt}
-              </span>
-              <span className="absolute right-4">▶</span>
-            </div>
-            <p className="mt-[1rem] whitespace-pre-wrap text-[0.75rem] text-gray-400">
-              {decription}
-            </p>
-          </li>
-        ))}
-      </ul>
+      <div className="absolute left-1/2 top-48 w-full -translate-x-1/2 overflow-x-scroll">
+        <ul className="flex gap-3 px-6">
+          {MOCK_CHANNEL.map(({ id, channelName, updatedAt, decription }) => (
+            <li
+              key={id}
+              className="relative w-52 flex-shrink-0 cursor-pointer rounded-[0.625rem] bg-white p-4 shadow-sm"
+            >
+              <div className="flex gap-2">
+                <span className="rounded-[1.25rem] bg-active-lightest p-1 px-2 text-[0.625rem] text-active-darken">
+                  {channelName}
+                </span>
+                <span className="rounded-[0.625rem] border border-gray-200 p-1 px-2 text-[0.5625rem] text-gray-400">
+                  {updatedAt}
+                </span>
+                <span className="absolute right-4">▶</span>
+              </div>
+              <p className="mt-[1rem] whitespace-pre-wrap text-xs text-gray-400">
+                {decription}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
 
       <section className="p-6 pb-12">
         <h1 className="mb-3 mt-16">전체글 보기</h1>
-        <ul className="mx-auto grid grid-cols-2 justify-center gap-x-5 gap-y-10">
+        <ul className="sm:grid-cols-3 md:grid-cols-4 grid grid-cols-2 justify-items-center gap-x-5 gap-y-10">
           {MOCK_POST.map(
             ({
               id,
@@ -208,7 +210,7 @@ const HomePage = () => {
               imageSrc,
               likes
             }) => (
-              <li key={id} className="w-40 ">
+              <li key={id} className="w-40">
                 <div className="relative h-28 cursor-pointer rounded-[0.625rem] bg-gray-200">
                   {imageSrc ? (
                     <img
@@ -225,7 +227,7 @@ const HomePage = () => {
                     {channelName}
                   </span>
                 </div>
-                <p className="cursor-pointer truncate p-1 text-[0.75rem] text-gray-500">
+                <p className="cursor-pointer truncate p-1 text-xs text-gray-500">
                   {title}
                 </p>
                 <div className="flex h-0 px-1 text-[0.5625rem] text-gray-400">

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -174,7 +174,7 @@ const HomePage = () => {
       </div>
 
       <div className="absolute left-1/2 top-48 w-full -translate-x-1/2 overflow-x-scroll">
-        <ul className="flex gap-3 px-6">
+        <ul className="inline-flex gap-3 px-6">
           {MOCK_CHANNEL.map(({ id, channelName, updatedAt, decription }) => (
             <li
               key={id}

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from 'react-router-dom';
 
 const Layout = () => {
   return (
-    <div className="font-OAGothic mx-auto h-screen max-w-[24.375rem]">
+    <div className="mx-auto max-w-[767px] font-OAGothic">
       <Outlet />
     </div>
   );

--- a/src/routes/LayoutWithFooter.tsx
+++ b/src/routes/LayoutWithFooter.tsx
@@ -2,10 +2,10 @@ import { Outlet } from 'react-router-dom';
 
 const LayoutWithFooter = () => {
   return (
-    <div className="mx-auto h-screen max-w-[24.375rem] font-OAGothic">
+    <>
       <Outlet />
       <div>푸터`~~</div>
-    </div>
+    </>
   );
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,13 +28,13 @@ export default {
         white: '#ffffff',
         black: '#000000'
       },
-      fontFamily: { OAGothic: ['OAGothic'] }
-    },
-    screens: {
-      mobile: {},
-      tablet: {},
-      desktop: {},
-      cs: '0px'
+      fontFamily: { OAGothic: ['OAGothic'] },
+      screens: {
+        mobile: {},
+        tablet: {},
+        desktop: {},
+        cs: '0px'
+      }
     }
   },
   plugins: []


### PR DESCRIPTION
## 구현 내용

전체 너비 768px(모바일이므로 max-width 값 767px)로 변경했습니다.

## 스크린샷
<img width="500" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/97094709/b11749d5-6498-4c99-84f4-0c8b548e94f9">


## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

결국 피그마에 있는 태블릿 디자인대로는 구현이 힘들 것 같네요! 하지만 max-width 값을 767px로 해주는 건 무조건 적용해야 할 것 같습니다.

767px이 모바일보다 넓기 때문에, 포스트 카드 관련 grid-cols 값은 스크린 크기별로 다르게 적용해줘야 할 것 같네요. 

```tsx
<ul className="sm:grid-cols-3 md:grid-cols-4 grid grid-cols-2 justify-items-center gap-x-5 gap-y-10">
```

## 이슈 번호

- close #104 

<!--## 테스트 계획 또는 완료 사항-->
