### PR TITLE
스토리북 사용 컴포넌트 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react": "^4.0.3",
         "autoprefixer": "^10.4.15",
+        "chromatic": "^7.1.0",
         "eslint": "^8.45.0",
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -8582,6 +8583,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chromatic": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-7.1.0.tgz",
+      "integrity": "sha512-4hvWVxj2TxsgmzQK7zsAIVapxF+mzAXFuYIoAKKACdKtI+kjz0GfKJYpnzD4xciY3SGaySsis6gWxJ9q8GIxiQ==",
+      "dev": true,
+      "bin": {
+        "chroma": "dist/bin.js",
+        "chromatic": "dist/bin.js",
+        "chromatic-cli": "dist/bin.js"
       }
     },
     "node_modules/chrome-trace-event": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "chromatic": "npx chromatic --project-token=chpt_41a4ed8071b0d7c"
   },
   "dependencies": {
     "@tanstack/react-query": "^4.33.0",
@@ -38,6 +39,7 @@
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10.4.15",
+    "chromatic": "^7.1.0",
     "eslint": "^8.45.0",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-react-hooks": "^4.6.0",
@@ -51,5 +53,7 @@
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
     "vite-plugin-svgr": "^3.2.0"
-  }
+  },
+  "readme": "ERROR: No README data found!",
+  "_id": "honkok@0.0.0"
 }

--- a/src/components/common/Avatar/Avatar.stories.tsx
+++ b/src/components/common/Avatar/Avatar.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Avatar from './Avatar';
 
 const meta: Meta<typeof Avatar> = {
-  title: 'Components/Avatar',
+  title: 'Components/Common/Avatar',
   component: Avatar,
   argTypes: { className: { table: { disable: true } } }
 };

--- a/src/components/common/Avatar/Avatar.stories.tsx
+++ b/src/components/common/Avatar/Avatar.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Avatar from './Avatar';
 
 const meta: Meta<typeof Avatar> = {
-  title: 'Component/Avatar',
+  title: 'Components/Avatar',
   component: Avatar,
   argTypes: {
     size: {

--- a/src/components/common/Avatar/Avatar.stories.tsx
+++ b/src/components/common/Avatar/Avatar.stories.tsx
@@ -4,20 +4,7 @@ import Avatar from './Avatar';
 const meta: Meta<typeof Avatar> = {
   title: 'Components/Avatar',
   component: Avatar,
-  argTypes: {
-    size: {
-      control: {
-        type: 'select',
-        options: ['small', 'medium', 'large']
-      }
-    },
-    status: {
-      control: {
-        type: 'select',
-        options: ['none', 'online', 'offline']
-      }
-    }
-  }
+  argTypes: { className: { table: { disable: true } } }
 };
 
 export default meta;

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -3,19 +3,19 @@ interface AvatarProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   status?: 'none' | 'online' | 'offline';
 }
 
-const sizesConfig = {
+const sizes = {
   small: 'w-10 h-10',
   medium: 'w-12 h-12',
   large: 'w-14 h-14'
 };
 
-const statusSizesConfig = {
+const badgeSizes = {
   small: 'w-2 h-2 bottom-[0.1rem] right-[0.1rem]',
   medium: 'w-3 h-3 bottom-[0.01rem] right-[0.01rem]',
   large: 'w-4 h-4 bottom-0 right-0'
 };
 
-const onlineConfig = {
+const statuses = {
   online: 'bg-sub-lime',
   offline: 'bg-gray-300'
 };
@@ -29,12 +29,13 @@ const Avatar = ({ size, status = 'none', ...props }: AvatarProps) => {
   return (
     <div className="relative inline-block">
       <img
-        className={`${avatarDefaultStyle} ${sizesConfig[size]}  ${className}`}
+        className={`${avatarDefaultStyle} ${sizes[size]} ${className}`}
         {...rest}
       />
+
       {status !== 'none' && (
         <div
-          className={`absolute rounded-full ${statusSizesConfig[size]} ${onlineConfig[status]}`}
+          className={`absolute rounded-full ${badgeSizes[size]} ${statuses[status]}`}
         />
       )}
     </div>

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -20,18 +20,14 @@ const statuses = {
   offline: 'bg-gray-300'
 };
 
-const avatarDefaultStyle =
-  'rounded-full object-contain border-[1px] border-gray-100';
+const defaults = 'rounded-full object-contain border-[1px] border-gray-100';
 
 const Avatar = ({ size, status = 'none', ...props }: AvatarProps) => {
   const { className, ...rest } = props;
 
   return (
     <div className="relative inline-block">
-      <img
-        className={`${avatarDefaultStyle} ${sizes[size]} ${className}`}
-        {...rest}
-      />
+      <img className={`${defaults} ${sizes[size]} ${className}`} {...rest} />
 
       {status !== 'none' && (
         <div

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -22,12 +22,15 @@ const statuses = {
 
 const defaults = 'rounded-full object-contain border-[1px] border-gray-100';
 
-const Avatar = ({ size, status = 'none', ...props }: AvatarProps) => {
-  const { className, ...rest } = props;
-
+const Avatar = ({
+  size,
+  status = 'none',
+  className,
+  ...props
+}: AvatarProps) => {
   return (
     <div className="relative inline-block">
-      <img className={`${defaults} ${sizes[size]} ${className}`} {...rest} />
+      <img className={`${defaults} ${sizes[size]} ${className}`} {...props} />
 
       {status !== 'none' && (
         <div

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -21,17 +21,20 @@ const onlineConfig = {
   offline: 'bg-gray-300'
 };
 
+const avatarDefaultStyle =
+  'rounded-full object-contain border-[1px] border-gray-100';
+
 const Avatar = ({
   size,
   status = 'none',
-  className,
+  className = '',
   ...props
 }: AvatarProps) => {
   return (
     <div className="relative inline-block">
       <img
         {...props}
-        className={`${sizesConfig[size]} rounded-full object-contain ${className} border-[1px] border-gray-100`}
+        className={`${avatarDefaultStyle} ${sizesConfig[size]}  ${className}`}
       />
       {status !== 'none' && (
         <div

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -1,7 +1,6 @@
 interface AvatarProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   size: 'small' | 'medium' | 'large';
   status?: 'none' | 'online' | 'offline';
-  className?: string;
 }
 
 const sizesConfig = {
@@ -24,17 +23,14 @@ const onlineConfig = {
 const avatarDefaultStyle =
   'rounded-full object-contain border-[1px] border-gray-100';
 
-const Avatar = ({
-  size,
-  status = 'none',
-  className = '',
-  ...props
-}: AvatarProps) => {
+const Avatar = ({ size, status = 'none', ...props }: AvatarProps) => {
+  const { className, ...rest } = props;
+
   return (
     <div className="relative inline-block">
       <img
-        {...props}
         className={`${avatarDefaultStyle} ${sizesConfig[size]}  ${className}`}
+        {...rest}
       />
       {status !== 'none' && (
         <div

--- a/src/components/common/Badge/Badge.stories.tsx
+++ b/src/components/common/Badge/Badge.stories.tsx
@@ -3,7 +3,10 @@ import Badge from './Badge';
 
 const meta: Meta<typeof Badge> = {
   title: 'Components/Badge',
-  component: Badge
+  component: Badge,
+  argTypes: {
+    className: { table: { disable: true } }
+  }
 };
 
 export default meta;

--- a/src/components/common/Badge/Badge.stories.tsx
+++ b/src/components/common/Badge/Badge.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Badge from './Badge';
 
 const meta: Meta<typeof Badge> = {
-  title: 'Components/Badge',
+  title: 'Components/Common/Badge',
   component: Badge,
   argTypes: {
     className: { table: { disable: true } }

--- a/src/components/common/Badge/Badge.stories.tsx
+++ b/src/components/common/Badge/Badge.stories.tsx
@@ -13,6 +13,6 @@ export default meta;
 type Story = StoryObj<typeof Badge>;
 
 export const Default: Story = {
-  args: { children: '기본', type: 'default' },
+  args: { children: 'My Badge', variant: 'outline' },
   render: (args) => <Badge {...args} />
 };

--- a/src/components/common/Badge/Badge.stories.tsx
+++ b/src/components/common/Badge/Badge.stories.tsx
@@ -2,16 +2,8 @@ import { Meta, StoryObj } from '@storybook/react';
 import Badge from './Badge';
 
 const meta: Meta<typeof Badge> = {
-  title: 'Component/Badge',
-  component: Badge,
-  argTypes: {
-    type: {
-      control: {
-        type: 'select',
-        options: ['default', 'channel', 'selectedChannel', 'primary']
-      }
-    }
-  }
+  title: 'Components/Badge',
+  component: Badge
 };
 
 export default meta;

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -16,7 +16,7 @@ const Badge = ({
     subtle: 'bg-active-lightest text-active-darken'
   };
 
-  const defaults = 'rounded-full p-1 px-2 text-[0.625rem]';
+  const defaults = 'h-min rounded-full p-1 px-2 text-[0.625rem]';
 
   return (
     <span

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -1,26 +1,25 @@
 import { PropsWithChildren } from 'react';
 
 interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
-  type?: 'default' | 'channel' | 'selectedChannel' | 'primary';
+  variant?: 'outline' | 'solid' | 'subtle';
 }
 
-const types = {
-  default: 'bg-white text-gray-400 border-gray-200 border',
-  channel: 'bg-gray-100 text-gray-500 ',
-  selectedChannel: 'bg-active-lightest text-active-darken',
-  primary: 'bg-white text-sub-red font-bold'
-};
-
 const Badge = ({
-  type = 'default',
+  variant = 'outline',
   children,
   ...props
 }: PropsWithChildren<BadgeProps>) => {
   const { className, ...rest } = props;
 
+  const variants = {
+    outline: 'bg-white text-gray-400 border-gray-200 border',
+    solid: 'bg-gray-100 text-gray-500',
+    subtle: 'bg-active-lightest text-active-darken'
+  };
+
   return (
     <span
-      className={`rounded-full p-1 px-2 text-[0.625rem] ${types[type]} ${className}`}
+      className={`rounded-full p-1 px-2 text-[0.625rem] ${variants[variant]} ${className}`}
       {...rest}
     >
       {children}

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -1,8 +1,7 @@
 import { PropsWithChildren } from 'react';
 
-interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   type?: 'default' | 'channel' | 'selectedChannel' | 'primary';
-  className?: string;
 }
 
 const typeStyleConfig = {
@@ -15,13 +14,14 @@ const typeStyleConfig = {
 const Badge = ({
   type = 'default',
   children,
-  className,
   ...props
 }: PropsWithChildren<BadgeProps>) => {
+  const { className, ...rest } = props;
+
   return (
     <span
-      {...props}
-      className={`box-border rounded-full p-1 px-2 text-[0.625rem] ${typeStyleConfig[type]} ${className}`}
+      className={`rounded-full p-1 px-2 text-[0.625rem] ${typeStyleConfig[type]} ${className}`}
+      {...rest}
     >
       {children}
     </span>

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -7,10 +7,9 @@ interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 const Badge = ({
   variant = 'outline',
   children,
+  className,
   ...props
 }: PropsWithChildren<BadgeProps>) => {
-  const { className, ...rest } = props;
-
   const variants = {
     outline: 'bg-white text-gray-400 border-gray-200 border',
     solid: 'bg-gray-100 text-gray-500',
@@ -20,7 +19,10 @@ const Badge = ({
   const defaults = 'rounded-full p-1 px-2 text-[0.625rem]';
 
   return (
-    <span className={`${defaults} ${variants[variant]} ${className}`} {...rest}>
+    <span
+      className={`${defaults} ${variants[variant]} ${className}`}
+      {...props}
+    >
       {children}
     </span>
   );

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -4,7 +4,7 @@ interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   type?: 'default' | 'channel' | 'selectedChannel' | 'primary';
 }
 
-const typeStyleConfig = {
+const types = {
   default: 'bg-white text-gray-400 border-gray-200 border',
   channel: 'bg-gray-100 text-gray-500 ',
   selectedChannel: 'bg-active-lightest text-active-darken',
@@ -20,7 +20,7 @@ const Badge = ({
 
   return (
     <span
-      className={`rounded-full p-1 px-2 text-[0.625rem] ${typeStyleConfig[type]} ${className}`}
+      className={`rounded-full p-1 px-2 text-[0.625rem] ${types[type]} ${className}`}
       {...rest}
     >
       {children}

--- a/src/components/common/Badge/Badge.tsx
+++ b/src/components/common/Badge/Badge.tsx
@@ -17,11 +17,10 @@ const Badge = ({
     subtle: 'bg-active-lightest text-active-darken'
   };
 
+  const defaults = 'rounded-full p-1 px-2 text-[0.625rem]';
+
   return (
-    <span
-      className={`rounded-full p-1 px-2 text-[0.625rem] ${variants[variant]} ${className}`}
-      {...rest}
-    >
+    <span className={`${defaults} ${variants[variant]} ${className}`} {...rest}>
       {children}
     </span>
   );

--- a/src/components/common/Buttons/Button.stories.tsx
+++ b/src/components/common/Buttons/Button.stories.tsx
@@ -17,5 +17,5 @@ export const Default: Story = {
     variant: 'solid',
     children: 'Click on me!'
   },
-  render: (args) => <Button {...args}>{args.children}</Button>
+  render: (args) => <Button {...args} />
 };

--- a/src/components/common/Buttons/Button.stories.tsx
+++ b/src/components/common/Buttons/Button.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Button from './Button';
 
 const meta: Meta<typeof Button> = {
-  title: 'Components/Button',
+  title: 'Components/Common/Button',
   component: Button,
   argTypes: { className: { table: { disable: true } } }
 };

--- a/src/components/common/Buttons/Button.stories.tsx
+++ b/src/components/common/Buttons/Button.stories.tsx
@@ -3,13 +3,19 @@ import Button from './Button';
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Button',
-  component: Button
+  component: Button,
+  argTypes: { className: { table: { disable: true } } }
 };
 
 export default meta;
 type Story = StoryObj<typeof Button>;
 
 export const Default: Story = {
-  args: { children: '버튼' },
+  args: {
+    theme: 'main',
+    size: 'md',
+    variant: 'solid',
+    children: 'Click on me!'
+  },
   render: (args) => <Button {...args}>{args.children}</Button>
 };

--- a/src/components/common/Buttons/Button.stories.tsx
+++ b/src/components/common/Buttons/Button.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Button from './Button';
 
 const meta: Meta<typeof Button> = {
-  title: 'Component/Button',
+  title: 'Components/Button',
   component: Button
 };
 
@@ -10,9 +10,6 @@ export default meta;
 type Story = StoryObj<typeof Button>;
 
 export const Default: Story = {
-  args: {
-    bgColor: 'primary',
-    children: 'Button'
-  },
-  render: (args) => <Button {...args} />
+  args: { children: '버튼' },
+  render: (args) => <Button {...args}>{args.children}</Button>
 };

--- a/src/components/common/Buttons/Button.tsx
+++ b/src/components/common/Buttons/Button.tsx
@@ -1,13 +1,13 @@
 import { PropsWithChildren } from 'react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  theme?: 'main' | 'active';
+  theme?: 'main' | 'active' | 'default';
   size?: 'xs' | 'sm' | 'md' | 'lg';
   variant?: 'solid' | 'outline';
 }
 
 export const Button = ({
-  theme = 'main',
+  theme = 'default',
   size = 'md',
   variant = 'solid',
   children,
@@ -15,34 +15,36 @@ export const Button = ({
 }: PropsWithChildren<ButtonProps>) => {
   const { className, ...rest } = props;
 
-  const textSizes = {
+  const sizes = {
     xs: 'text-xs',
     sm: 'text-sm',
     md: 'text-base',
     lg: 'text-lg'
   };
 
-  const solidColors = {
+  const solid = {
     main: 'bg-main-base text-white hover:bg-main-darken',
-    active: 'bg-active-base text-white hover:bg-active-darken'
+    active: 'bg-active-base text-white hover:bg-active-darken',
+    default: ''
   };
 
-  const outlineColors = {
+  const outline = {
     main: 'bg-transparent border-[1px] border-main-base text-main-darken hover:bg-main-lighten',
     active:
-      'bg-transparent border-[1px] border-active-base text-active-darken hover:bg-active-lighten'
+      'bg-transparent border-[1px] border-active-base text-active-darken hover:bg-active-lighten',
+    default: ''
   };
 
   const variants = {
-    solid: solidColors[theme],
-    outline: outlineColors[theme]
+    solid: solid[theme],
+    outline: outline[theme]
   };
 
   const buttonDefaultStyle = 'p-[0.5rem] rounded-[0.625rem] transition';
 
   return (
     <button
-      className={`${buttonDefaultStyle} ${textSizes[size]} ${variants[variant]} ${className}`}
+      className={`${buttonDefaultStyle} ${sizes[size]} ${variants[variant]} ${className}`}
       {...rest}
     >
       {children}

--- a/src/components/common/Buttons/Button.tsx
+++ b/src/components/common/Buttons/Button.tsx
@@ -11,10 +11,9 @@ export const Button = ({
   size = 'md',
   variant = 'solid',
   children,
+  className,
   ...props
 }: PropsWithChildren<ButtonProps>) => {
-  const { className, ...rest } = props;
-
   const sizes = {
     xs: 'text-xs',
     sm: 'text-sm',
@@ -45,7 +44,7 @@ export const Button = ({
   return (
     <button
       className={`${defaults} ${sizes[size]} ${variants[variant]} ${className}`}
-      {...rest}
+      {...props}
     >
       {children}
     </button>

--- a/src/components/common/Buttons/Button.tsx
+++ b/src/components/common/Buttons/Button.tsx
@@ -40,11 +40,11 @@ export const Button = ({
     outline: outline[theme]
   };
 
-  const buttonDefaultStyle = 'p-[0.5rem] rounded-[0.625rem] transition';
+  const defaults = 'p-[0.5rem] rounded-[0.625rem] transition';
 
   return (
     <button
-      className={`${buttonDefaultStyle} ${sizes[size]} ${variants[variant]} ${className}`}
+      className={`${defaults} ${sizes[size]} ${variants[variant]} ${className}`}
       {...rest}
     >
       {children}

--- a/src/components/common/Buttons/Button.tsx
+++ b/src/components/common/Buttons/Button.tsx
@@ -1,35 +1,48 @@
 import { PropsWithChildren } from 'react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  bgColor?: 'primary' | 'secondary';
-  size?: 'small' | 'medium' | 'large';
+  theme?: 'main' | 'active';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
+  variant?: 'solid' | 'outline';
   className?: string;
 }
 
 export const Button = ({
-  bgColor = 'primary',
-  size = 'medium',
-  className,
+  theme = 'main',
+  size = 'md',
+  className = '',
+  variant = 'solid',
   children,
   ...props
 }: PropsWithChildren<ButtonProps>) => {
   const textSizes = {
-    small: 'text-xs',
-    medium: 'text-sm',
-    large: 'text-xl'
+    xs: 'text-xs',
+    sm: 'text-sm',
+    md: 'text-base',
+    lg: 'text-lg'
   };
 
-  const color = {
-    primary: 'bg-main-lighten',
-    secondary: 'bg-main-darken'
+  const solidColors = {
+    main: 'bg-main-base text-white hover:bg-main-darken',
+    active: 'bg-active-base text-white hover:bg-active-darken'
   };
 
-  const buttonDefaultStyle =
-    'border-2 px-2 py-1 cursor-pointer inline-block leading-1';
+  const outlineColors = {
+    main: 'bg-transparent border-[1px] border-main-base text-main-darken hover:bg-main-lighten',
+    active:
+      'bg-transparent border-[1px] border-active-base text-active-darken hover:bg-active-lighten'
+  };
+
+  const variants = {
+    solid: solidColors[theme],
+    outline: outlineColors[theme]
+  };
+
+  const buttonDefaultStyle = 'p-[0.5rem] rounded-[0.625rem] transition';
 
   return (
     <button
-      className={`${textSizes[size]} ${color[bgColor]} ${buttonDefaultStyle} ${className}`}
+      className={`${buttonDefaultStyle} ${textSizes[size]} ${variants[variant]} ${className}`}
       {...props}
     >
       {children}

--- a/src/components/common/Buttons/Button.tsx
+++ b/src/components/common/Buttons/Button.tsx
@@ -4,17 +4,17 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   theme?: 'main' | 'active';
   size?: 'xs' | 'sm' | 'md' | 'lg';
   variant?: 'solid' | 'outline';
-  className?: string;
 }
 
 export const Button = ({
   theme = 'main',
   size = 'md',
-  className = '',
   variant = 'solid',
   children,
   ...props
 }: PropsWithChildren<ButtonProps>) => {
+  const { className, ...rest } = props;
+
   const textSizes = {
     xs: 'text-xs',
     sm: 'text-sm',
@@ -43,7 +43,7 @@ export const Button = ({
   return (
     <button
       className={`${buttonDefaultStyle} ${textSizes[size]} ${variants[variant]} ${className}`}
-      {...props}
+      {...rest}
     >
       {children}
     </button>

--- a/src/components/common/Cards/Card.stories.tsx
+++ b/src/components/common/Cards/Card.stories.tsx
@@ -1,28 +1,24 @@
 import { Meta, StoryObj } from '@storybook/react';
 import Card from './Card';
-import CardTitle from './CardTitle';
 import { Image } from '~/components/common';
 
 const meta: Meta<typeof Card> = {
   title: 'Components/Card',
-  component: Card,
-  argTypes: { title: { type: 'string' } }
+  component: Card
 };
 
 export default meta;
 type Story = StoryObj<typeof Card>;
 
-export const ExampleCard: Story = {
-  args: {
-    title: 'title'
-  },
+export const Default: Story = {
+  args: { title: 'Card Title', direction: 'row' },
   render: (args) => (
-    <Card>
+    <Card {...args}>
       <Image
         className="h-40 w-40"
         src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
       />
-      <CardTitle>{args.title}</CardTitle>
+      <h1>{args.title}</h1>
     </Card>
   )
 };

--- a/src/components/common/Cards/Card.stories.tsx
+++ b/src/components/common/Cards/Card.stories.tsx
@@ -3,7 +3,7 @@ import Card from './Card';
 import { Image } from '~/components/common';
 
 const meta: Meta<typeof Card> = {
-  title: 'Components/Card',
+  title: 'Components/Common/Card',
   component: Card
 };
 

--- a/src/components/common/Cards/Card.stories.tsx
+++ b/src/components/common/Cards/Card.stories.tsx
@@ -4,13 +4,9 @@ import CardTitle from './CardTitle';
 import { Image } from '~/components/common';
 
 const meta: Meta<typeof Card> = {
-  title: 'Component/Card',
+  title: 'Components/Card',
   component: Card,
-  argTypes: {
-    title: {
-      type: 'string'
-    }
-  }
+  argTypes: { title: { type: 'string' } }
 };
 
 export default meta;

--- a/src/components/common/Cards/Card.tsx
+++ b/src/components/common/Cards/Card.tsx
@@ -1,19 +1,24 @@
+import { PropsWithChildren } from 'react';
+
 interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
   direction?: 'row' | 'col';
 }
 
-const directionConfig = {
+const directions = {
   row: 'flex-row',
   col: 'flex-col'
 };
 
-const Card = ({ children, direction = 'col', ...props }: CardProps) => {
+const Card = ({
+  children,
+  direction = 'col',
+  ...props
+}: PropsWithChildren<CardProps>) => {
   const { className, ...rest } = props;
 
   return (
     <div
-      className={`flex ${directionConfig[direction]} h-fit w-fit gap-2 rounded-md border p-3 shadow-md ${className}`}
+      className={`flex ${directions[direction]} h-fit w-fit gap-2 rounded-md border p-3 shadow-md ${className}`}
       {...rest}
     >
       {children}

--- a/src/components/common/Cards/Card.tsx
+++ b/src/components/common/Cards/Card.tsx
@@ -8,16 +8,13 @@ const directionConfig = {
   col: 'flex-col'
 };
 
-const Card = ({
-  children,
-  direction = 'col',
-  className,
-  ...props
-}: CardProps) => {
+const Card = ({ children, direction = 'col', ...props }: CardProps) => {
+  const { className, ...rest } = props;
+
   return (
     <div
       className={`flex ${directionConfig[direction]} h-fit w-fit gap-2 rounded-md border p-3 shadow-md ${className}`}
-      {...props}
+      {...rest}
     >
       {children}
     </div>

--- a/src/components/common/Cards/Card.tsx
+++ b/src/components/common/Cards/Card.tsx
@@ -16,9 +16,11 @@ const Card = ({
 }: PropsWithChildren<CardProps>) => {
   const { className, ...rest } = props;
 
+  const defualts = 'flex h-fit w-fit gap-2 rounded-md border p-3 shadow-md';
+
   return (
     <div
-      className={`flex ${directions[direction]} h-fit w-fit gap-2 rounded-md border p-3 shadow-md ${className}`}
+      className={`${defualts} ${directions[direction]} ${className}`}
       {...rest}
     >
       {children}

--- a/src/components/common/Cards/Card.tsx
+++ b/src/components/common/Cards/Card.tsx
@@ -13,16 +13,15 @@ const directions = {
 const Card = ({
   children,
   direction = 'col',
+  className,
   ...props
 }: PropsWithChildren<CardProps>) => {
-  const { className, ...rest } = props;
-
   const defualts = 'flex h-fit w-fit gap-2 rounded-md border p-3 shadow-md';
 
   return (
     <div
       className={`${defualts} ${directions[direction]} ${className}`}
-      {...rest}
+      {...props}
     >
       {children}
     </div>

--- a/src/components/common/Cards/Card.tsx
+++ b/src/components/common/Cards/Card.tsx
@@ -9,6 +9,7 @@ const directions = {
   col: 'flex-col'
 };
 
+/** @todo CardBody 만들기 */
 const Card = ({
   children,
   direction = 'col',

--- a/src/components/common/Cards/CardTitle.tsx
+++ b/src/components/common/Cards/CardTitle.tsx
@@ -1,7 +1,0 @@
-import { PropsWithChildren } from 'react';
-
-const CardTitle = ({ children }: PropsWithChildren) => {
-  return <h1 className="font-medium">{children}</h1>;
-};
-
-export default CardTitle;

--- a/src/components/common/Cards/index.ts
+++ b/src/components/common/Cards/index.ts
@@ -1,2 +1,1 @@
 export { default as Card } from './Card';
-export { default as CardTitle } from './CardTitle';

--- a/src/components/common/Image/Image.stories.tsx
+++ b/src/components/common/Image/Image.stories.tsx
@@ -3,12 +3,7 @@ import Image from './Image';
 
 const meta: Meta<typeof Image> = {
   title: 'Components/Image',
-  component: Image,
-  argTypes: {
-    title: {
-      src: 'string'
-    }
-  }
+  component: Image
 };
 
 export default meta;

--- a/src/components/common/Image/Image.stories.tsx
+++ b/src/components/common/Image/Image.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Image from './Image';
 
 const meta: Meta<typeof Image> = {
-  title: 'Components/Image',
+  title: 'Components/Common/Image',
   component: Image
 };
 

--- a/src/components/common/Image/Image.stories.tsx
+++ b/src/components/common/Image/Image.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Image from './Image';
 
 const meta: Meta<typeof Image> = {
-  title: 'Component/Image',
+  title: 'Components/Image',
   component: Image,
   argTypes: {
     title: {

--- a/src/components/common/Image/Image.tsx
+++ b/src/components/common/Image/Image.tsx
@@ -1,11 +1,11 @@
-interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
-  src: string;
-}
+interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
 
-const Image = ({ src, ...props }: ImageProps) => {
+const Image = ({ ...props }: ImageProps) => {
   const { className, ...rest } = props;
 
-  return <img src={src} className={`rounded-md ${className}`} {...rest} />;
+  const defaults = 'rounded-md';
+
+  return <img className={`${defaults} ${className}`} {...rest} />;
 };
 
 export default Image;

--- a/src/components/common/Image/Image.tsx
+++ b/src/components/common/Image/Image.tsx
@@ -1,10 +1,11 @@
 interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   src: string;
-  className?: string;
 }
 
-const Image = ({ src, className, ...props }: ImageProps) => {
-  return <img src={src} {...props} className={`rounded-md ${className}`} />;
+const Image = ({ src, ...props }: ImageProps) => {
+  const { className, ...rest } = props;
+
+  return <img src={src} className={`rounded-md ${className}`} {...rest} />;
 };
 
 export default Image;

--- a/src/components/common/Image/Image.tsx
+++ b/src/components/common/Image/Image.tsx
@@ -1,11 +1,9 @@
 interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {}
 
-const Image = ({ ...props }: ImageProps) => {
-  const { className, ...rest } = props;
-
+const Image = ({ className, ...props }: ImageProps) => {
   const defaults = 'rounded-md';
 
-  return <img className={`${defaults} ${className}`} {...rest} />;
+  return <img className={`${defaults} ${className}`} {...props} />;
 };
 
 export default Image;

--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Input from './Input';
 
 const meta: Meta<typeof Input> = {
-  title: 'Components/Input',
+  title: 'Components/Common/Input',
   component: Input,
   argTypes: {
     onChange: { action: 'onChange' }

--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Input from './Input';
 
 const meta: Meta<typeof Input> = {
-  title: 'Component/Input',
+  title: 'Components/Input',
   component: Input,
   argTypes: {
     onChange: { action: 'onChange' }

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,12 +1,10 @@
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-const Input = ({ type, ...props }: InputProps) => {
-  const { className, ...rest } = props;
-
+const Input = ({ className, ...props }: InputProps) => {
   const defaults =
     'rounded-[0.625rem] border-[1.5px] border-gray-200 pb-[0.56rem] pl-[0.87rem] pt-[0.5rem] placeholder:text-gray-200 focus:outline-main-base';
 
-  return <input className={`${defaults} ${className}`} {...rest} />;
+  return <input className={`${defaults} ${className}`} {...props} />;
 };
 
 export default Input;

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -3,7 +3,8 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 const Input = ({ type, ...props }: InputProps) => {
   const { className, ...rest } = props;
 
-  const defaults = 'border bg-white px-2 py-1 focus:outline-none';
+  const defaults =
+    'rounded-[0.625rem] border-[1.5px] border-gray-200 pb-[0.56rem] pl-[0.87rem] pt-[0.5rem] placeholder:text-gray-200 focus:outline-main-base';
 
   return <input className={`${defaults} ${className}`} {...rest} />;
 };

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,10 +1,10 @@
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  className?: string;
-}
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-const Input = ({ type, className, ...props }: InputProps) => {
+const Input = ({ type, ...props }: InputProps) => {
+  const { className, ...rest } = props;
+
   return (
-    <input className={`border bg-white px-2 py-1 ${className}`} {...props} />
+    <input className={`border bg-white px-2 py-1 ${className}`} {...rest} />
   );
 };
 

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -3,9 +3,9 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 const Input = ({ type, ...props }: InputProps) => {
   const { className, ...rest } = props;
 
-  return (
-    <input className={`border bg-white px-2 py-1 ${className}`} {...rest} />
-  );
+  const defaults = 'border bg-white px-2 py-1 focus:outline-none';
+
+  return <input className={`${defaults} ${className}`} {...rest} />;
 };
 
 export default Input;

--- a/src/components/domain/List/List.stories.tsx
+++ b/src/components/domain/List/List.stories.tsx
@@ -3,7 +3,7 @@ import { List, ListItem } from '.';
 import { Avatar, Image, Card, CardTitle } from '~/components/common';
 
 const meta: Meta<typeof List> = {
-  title: 'Component/List',
+  title: 'Components/List',
   component: List
 };
 
@@ -11,9 +11,7 @@ export default meta;
 type Story = StoryObj<typeof List>;
 
 export const Default: Story = {
-  args: {
-    columns: '2'
-  },
+  args: { types: 'post' },
   render: (args) => (
     <List {...args}>
       <ListItem>

--- a/src/components/domain/List/List.stories.tsx
+++ b/src/components/domain/List/List.stories.tsx
@@ -3,7 +3,7 @@ import { List, ListItem } from '.';
 import { Avatar, Image, Card } from '~/components/common';
 
 const meta: Meta<typeof List> = {
-  title: 'Components/List',
+  title: 'Components/Domain/List',
   component: List
 };
 

--- a/src/components/domain/List/List.stories.tsx
+++ b/src/components/domain/List/List.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { List, ListItem } from '.';
-import { Avatar, Image, Card, CardTitle } from '~/components/common';
+import { Avatar, Image, Card } from '~/components/common';
 
 const meta: Meta<typeof List> = {
   title: 'Components/List',
@@ -11,7 +11,7 @@ export default meta;
 type Story = StoryObj<typeof List>;
 
 export const Default: Story = {
-  args: { types: 'post' },
+  args: { column: 1 },
   render: (args) => (
     <List {...args}>
       <ListItem>
@@ -20,7 +20,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -29,7 +29,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -38,7 +38,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -47,7 +47,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -56,7 +56,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -65,7 +65,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -74,7 +74,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -83,7 +83,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -92,7 +92,7 @@ export const Default: Story = {
             className="aspect-square"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>타이틀</CardTitle>
+          <h1>타이틀</h1>
         </Card>
       </ListItem>
     </List>
@@ -100,9 +100,7 @@ export const Default: Story = {
 };
 
 export const ChatList: Story = {
-  args: {
-    columns: '1'
-  },
+  args: { column: 1 },
   render: (args) => (
     <List {...args}>
       <ListItem>
@@ -112,7 +110,7 @@ export const ChatList: Story = {
             size="medium"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>내용을 일단 적기</CardTitle>
+          <h1>내용을 일단 적기</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -122,7 +120,7 @@ export const ChatList: Story = {
             size="medium"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>내용을 일단 적기</CardTitle>
+          <h1>내용을 일단 적기</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -132,7 +130,7 @@ export const ChatList: Story = {
             size="medium"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>내용을 일단 적기</CardTitle>
+          <h1>내용을 일단 적기</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -142,7 +140,7 @@ export const ChatList: Story = {
             size="medium"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>내용을 일단 적기</CardTitle>
+          <h1>내용을 일단 적기</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -152,7 +150,7 @@ export const ChatList: Story = {
             size="medium"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>내용을 일단 적기</CardTitle>
+          <h1>내용을 일단 적기</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -162,7 +160,7 @@ export const ChatList: Story = {
             size="medium"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>내용을 일단 적기</CardTitle>
+          <h1>내용을 일단 적기</h1>
         </Card>
       </ListItem>
       <ListItem>
@@ -172,7 +170,7 @@ export const ChatList: Story = {
             size="medium"
             src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
           />
-          <CardTitle>내용을.. 일단 적기</CardTitle>
+          <h1>내용을.. 일단 적기</h1>
         </Card>
       </ListItem>
     </List>

--- a/src/components/domain/List/List.tsx
+++ b/src/components/domain/List/List.tsx
@@ -1,40 +1,40 @@
 import { HTMLAttributes, PropsWithChildren } from 'react';
 
 interface ListProps extends HTMLAttributes<HTMLUListElement> {
-  columns?: '1' | '2';
-  className?: string;
+  column?: 1 | 2;
 }
 
-interface ListItemProps extends HTMLAttributes<HTMLUListElement> {
-  className?: string;
-}
+interface ListItemProps extends HTMLAttributes<HTMLLIElement> {}
 
-const columnsConfig = {
-  '1': 'grid-cols-1',
-  '2': 'grid-cols-2'
+const columns = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2'
 };
 
-const BASE_BUTTON_CLASSES = 'mx-2 grid gap-2';
+const defaults = 'mx-2 grid gap-2';
 
 const List = ({
-  className = '',
   children,
-  columns = '2'
+  column = 2,
+  ...props
 }: PropsWithChildren<ListProps>) => {
+  const { className, ...rest } = props;
+
   return (
-    <ul
-      className={`${BASE_BUTTON_CLASSES} ${className} ${columnsConfig[columns]}`}
-    >
+    <ul className={`${defaults} ${className} ${columns[column]}`} {...rest}>
       {children}
     </ul>
   );
 };
 
-const ListItem = ({
-  className,
-  children
-}: PropsWithChildren<ListItemProps>) => {
-  return <li className={`${className}`}>{children}</li>;
+const ListItem = ({ children, ...props }: PropsWithChildren<ListItemProps>) => {
+  const { className, ...rest } = props;
+
+  return (
+    <li className={`${className}`} {...rest}>
+      {children}
+    </li>
+  );
 };
 
 export { List, ListItem };

--- a/src/components/domain/List/List.tsx
+++ b/src/components/domain/List/List.tsx
@@ -16,22 +16,23 @@ const defaults = 'mx-2 grid gap-2';
 const List = ({
   children,
   column = 2,
+  className,
   ...props
 }: PropsWithChildren<ListProps>) => {
-  const { className, ...rest } = props;
-
   return (
-    <ul className={`${defaults} ${className} ${columns[column]}`} {...rest}>
+    <ul className={`${defaults} ${className} ${columns[column]}`} {...props}>
       {children}
     </ul>
   );
 };
 
-const ListItem = ({ children, ...props }: PropsWithChildren<ListItemProps>) => {
-  const { className, ...rest } = props;
-
+const ListItem = ({
+  children,
+  className,
+  ...props
+}: PropsWithChildren<ListItemProps>) => {
   return (
-    <li className={`${className}`} {...rest}>
+    <li className={`${className}`} {...props}>
       {children}
     </li>
   );

--- a/src/components/domain/PostItem/PostItem.stories.tsx
+++ b/src/components/domain/PostItem/PostItem.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import PostItem from './PostItem';
 
 const meta: Meta<typeof PostItem> = {
-  title: 'Component/PostCard',
+  title: 'Components/PostCard',
   component: PostItem
 };
 

--- a/src/components/domain/PostItem/PostItem.stories.tsx
+++ b/src/components/domain/PostItem/PostItem.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import PostItem from './PostItem';
 
 const meta: Meta<typeof PostItem> = {
-  title: 'Components/PostCard',
+  title: 'Components/Domain/PostCard',
   component: PostItem
 };
 

--- a/src/components/domain/PostItem/PostItem.tsx
+++ b/src/components/domain/PostItem/PostItem.tsx
@@ -6,7 +6,7 @@ const PostItem = () => {
     <li className="h-40 w-40">
       <div className="relative">
         <Image src="https://storage.enuri.info/pic_upload/knowbox2/202208/023349314202208210721f7ed-31bd-45f8-8a1b-7faf2adc2e45.jpg" />
-        <Badge type="selectedChannel" className="absolute left-2 top-2">
+        <Badge variant="subtle" className="absolute left-2 top-2">
           요리조리
         </Badge>
       </div>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,4 +1,5 @@
 import SeatedMan from './SeatedMan';
+import { Badge } from '~/components/common';
 
 const MOCK_CHANNEL = [
   {
@@ -181,12 +182,8 @@ const HomePage = () => {
               className="relative w-52 flex-shrink-0 cursor-pointer rounded-[0.625rem] bg-white p-4 shadow-sm"
             >
               <div className="flex gap-2">
-                <span className="rounded-[1.25rem] bg-active-lightest p-1 px-2 text-[0.625rem] text-active-darken">
-                  {channelName}
-                </span>
-                <span className="rounded-[0.625rem] border border-gray-200 p-1 px-2 text-[0.5625rem] text-gray-400">
-                  {updatedAt}
-                </span>
+                <Badge variant="subtle">{channelName}</Badge>
+                <Badge>{updatedAt}</Badge>
                 <span className="absolute right-4">▶</span>
               </div>
               <p className="mt-[1rem] whitespace-pre-wrap text-xs text-gray-400">

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -154,8 +154,6 @@ const MOCK_POST = [
 const HomePage = () => {
   return (
     <div className="relative h-full bg-gray-100">
-      <Button>123123123</Button>
-      <Badge>123123</Badge>
       <div className="h-[14.625rem] bg-main-lighten p-6">
         <div className="flex">
           <div className="grow">

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,5 +1,4 @@
 import SeatedMan from './SeatedMan';
-import { Badge, Button } from '~/components/common';
 
 const MOCK_CHANNEL = [
   {

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,4 +1,5 @@
 import SeatedMan from './SeatedMan';
+import { Badge, Button } from '~/components/common';
 
 const MOCK_CHANNEL = [
   {
@@ -153,6 +154,8 @@ const MOCK_POST = [
 const HomePage = () => {
   return (
     <div className="relative h-full bg-gray-100">
+      <Button>123123123</Button>
+      <Badge>123123</Badge>
       <div className="h-[14.625rem] bg-main-lighten p-6">
         <div className="flex">
           <div className="grow">
@@ -199,7 +202,7 @@ const HomePage = () => {
 
       <section className="p-6 pb-12">
         <h1 className="mb-3 mt-16">전체글 보기</h1>
-        <ul className="sm:grid-cols-3 md:grid-cols-4 grid grid-cols-2 justify-items-center gap-x-5 gap-y-10">
+        <ul className="grid grid-cols-2 justify-items-center gap-x-5 gap-y-10 sm:grid-cols-3 md:grid-cols-4">
           {MOCK_POST.map(
             ({
               id,

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,4 +1,5 @@
 import Warning from './Warning';
+import { Button } from '~/components/common';
 
 const NotFoundPage = () => {
   const handleClick = () => {
@@ -10,12 +11,10 @@ const NotFoundPage = () => {
       <Warning />
       <h1 className="mt-8 text-2xl">404 ERROR</h1>
       <p className="mt-2 text-gray-400">페이지를 찾을 수 없습니다.</p>
-      <button
-        className="mt-16 h-12 w-40 rounded-[0.625rem] border-none bg-main-base font-normal text-white"
-        onClick={handleClick}
-      >
+
+      <Button onClick={handleClick} theme="main" className="mt-16 h-12 w-40">
         홈으로
-      </button>
+      </Button>
     </div>
   );
 };

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -1,3 +1,5 @@
+import { Badge, Button, Input } from '~/components/common';
+
 const CHANNEL_MOCKS = [
   '도와주세요',
   '요리조리',
@@ -22,8 +24,8 @@ const PostEdit = () => {
               fill="none"
             >
               <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
+                fillRule="evenodd"
+                clipRule="evenodd"
                 d="M9.71396 17.7122C10.096 17.3292 10.0952 16.7089 9.7122 16.3269L2.36671 9L9.7122 1.67315C10.0952 1.29108 10.096 0.670837 9.71396 0.287798C9.3319 -0.0952435 8.71165 -0.0960293 8.32861 0.286037L0.287796 8.30645C0.103549 8.49023 0 8.73977 0 9C0 9.26024 0.103549 9.50978 0.287796 9.69356L8.32861 17.714C8.71165 18.096 9.3319 18.0952 9.71396 17.7122Z"
                 fill="white"
               />
@@ -43,12 +45,9 @@ const PostEdit = () => {
       <div className="mb-[1.67rem] px-[1.5rem]">
         <ul className="flex gap-[0.7rem] overflow-auto whitespace-nowrap">
           {CHANNEL_MOCKS.map((channel) => (
-            <li
-              key={channel}
-              className="flex h-[1.3255rem] flex-col justify-center rounded-[1.25rem] bg-gray-100 px-[0.75rem] text-[0.625rem]"
-            >
-              <span>{channel}</span>
-            </li>
+            <Badge key={channel} variant="solid">
+              {channel}
+            </Badge>
           ))}
         </ul>
       </div>
@@ -56,10 +55,7 @@ const PostEdit = () => {
       <div className="relative">
         <form>
           <div className="mb-[1.7rem] px-[0.75rem]">
-            <input
-              placeholder="제목을 입력해주세요."
-              className="w-full border-[1.5px] border-gray-200 py-[0.69rem] pl-[0.81rem] pr-[2.44rem] placeholder:text-[1.25rem] placeholder:text-gray-200 focus:outline-main-base"
-            />
+            <Input placeholder="제목을 입력해주세요." className="w-full" />
           </div>
           <div className="mb-[1.63rem] flex h-[14.375rem] gap-[0.81rem] overflow-auto whitespace-nowrap">
             <div className="w-[21.375rem] flex-shrink-0 rounded-[0.3125rem] bg-gray-100" />
@@ -75,9 +71,9 @@ const PostEdit = () => {
                   <path
                     d="M21 12.2735V5.39316C21 4.8718 20.7893 4.37179 20.4142 4.00313C20.0391 3.63446 19.5304 3.42735 19 3.42735H5C4.46957 3.42735 3.96086 3.63446 3.58579 4.00313C3.21071 4.37179 3 4.8718 3 5.39316V16.2051M21 12.2735V19.1538C21 19.6752 20.7893 20.1752 20.4142 20.5439C20.0391 20.9125 19.5304 21.1197 19 21.1197H16M21 12.2735C14.558 12.2735 10.895 14.2246 8.945 16.444M3 16.2051V19.1538C3 19.6752 3.21071 20.1752 3.58579 20.5439C3.96086 20.9125 4.46957 21.1197 5 21.1197H16M3 16.2051C4.403 15.9751 6.637 15.9171 8.945 16.444M16 21.1197C14.296 18.399 11.573 17.0426 8.945 16.444M8.5 7.35898C8 7.35898 7 7.65385 7 8.83334C7 10.0128 8 10.3077 8.5 10.3077C9 10.3077 10 10.0128 10 8.83334C10 7.65385 9 7.35898 8.5 7.35898Z"
                     stroke="#5F5F5F"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                   />
                 </svg>
                 <span className="text-[0.875rem] text-gray-400">사진 추가</span>
@@ -90,9 +86,12 @@ const PostEdit = () => {
               className="w-full  resize-none placeholder:text-gray-200 focus:outline-main-base"
             />
           </div>
-          <button className="fixed bottom-[2.19rem] left-[calc(50%+5rem)] rounded-[0.625rem] bg-main-base px-[0.8rem] py-[0.7rem] text-white">
+          <Button
+            theme="main"
+            className="fixed bottom-[2.19rem] left-[calc(70%)] px-[0.8rem] py-[0.7rem]"
+          >
             등록하기
-          </button>
+          </Button>
         </form>
       </div>
     </div>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,3 +1,5 @@
+import { Button, Input } from '~/components/common';
+
 const SignupPage = () => {
   return (
     <div className="px-[1.5rem]">
@@ -31,12 +33,12 @@ const SignupPage = () => {
             </h3>
 
             <div>
-              <input
+              <Input
                 type="email"
                 placeholder="아이디를 입력해주세요."
-                className="focus:outline-main-base w-full rounded-[0.625rem] border-[1.5px] border-solid border-gray-200 pb-[0.56rem] pl-[0.87rem] pt-[0.5rem] placeholder:text-gray-200"
+                className="w-full"
               />
-              <p className="text-sub-green mt-[0.12rem] pl-[0.44rem] text-[0.6875rem]">
+              <p className="mt-[0.12rem] pl-[0.44rem] text-[0.6875rem] text-sub-green">
                 알맞은 아이디입니다 :)
               </p>
             </div>
@@ -47,31 +49,31 @@ const SignupPage = () => {
               비밀번호 입력
             </h3>
             <div className="mb-[0.75rem]">
-              <input
+              <Input
                 type="password"
                 placeholder="비밀번호 입력"
-                className="focus:outline-main-base w-full rounded-[0.625rem] border-[1.5px] border-solid border-gray-200 pb-[0.56rem] pl-[0.87rem] pt-[0.5rem] placeholder:text-gray-200"
+                className="w-full"
               />
-              <p className="text-sub-green mt-[0.12rem] pl-[0.44rem] text-[0.6875rem]">
+              <p className="mt-[0.12rem] pl-[0.44rem] text-[0.6875rem] text-sub-green">
                 알맞은 비밀번호입니다 :)
               </p>
             </div>
 
             <div>
-              <input
+              <Input
                 type="password"
                 placeholder="비밀번호 확인"
-                className="focus:outline-main-base w-full rounded-[0.625rem] border-[1.5px] border-solid border-gray-200 pb-[0.56rem] pl-[0.87rem] pt-[0.5rem] placeholder:text-gray-200"
+                className="w-full"
               />
-              <p className="text-sub-red mt-[0.12rem] pl-[0.44rem] text-[0.6875rem]">
+              <p className="mt-[0.12rem] pl-[0.44rem] text-[0.6875rem] text-sub-red">
                 동일한 비밀번호를 입력해주세요.
               </p>
             </div>
           </div>
 
-          <button className="bg-main-base h-[3.4375rem] w-full rounded-[0.625rem] text-white">
+          <Button theme="main" className="h-[3.4375rem] w-full">
             회원가입 완료
-          </button>
+          </Button>
         </form>
       </div>
     </div>

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -72,6 +72,7 @@ const getPosts = async ({ channelId, limit, offset }: GetPosts) => {
   if (!channelId) {
     return;
   }
+
   return await snsApiClient.get(`/posts/channel/${channelId}`, {
     params: { limit, offset }
   });


### PR DESCRIPTION
## 구현 내용

스토리북과 관련된 전반적인 작업을 진행했습니다.
문서도 이어서 작성하겠습니다.

[chromatic 배포](https://www.chromatic.com/build?appId=6505968b13336cb9fd5be4bf&number=2)

<!-- ## 스크린샷 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

기존 만들어진 컴포넌트들을 건드리는 작업이어서 더욱 어렵게 느껴졌네요.
최대한 다른 팀원이 컴포넌트를 봤을 때 어떻게 하면 쉽게 쓸 수 있을까 를 생각하면서 작업을 진행하려 했는데요.
그럼에도 저의 주관이 많이 들어가게 되더라구요..

일부 페이지에서 컴포넌트를 사용해봐서 파일 개수가 더 많아졌네요.. 😇

### 주요 작업 내용

많이 신경쓴 부분은 이름이나 타입과 같은 부분에서 규칙과 일관성을 가져가보려고 했습니다.
이전 컴포넌트들은 사용하는 부분이 다 제각각이고 파편화가 심해서 코드가 쉽게 읽히지 않는 것 같았습니다.

그래서 이번 작업에서 최대한 공통된 이름과 형태를 가져가보려고 했는데요.
주로 사용하는 이름으로는 `variants`, `defaults` 등이 있을 것 같네요. 코드를 한 번 살펴봐주시면 감사하겠습니다.

스토리북과 관련해서도 최대한 지저분한 부분을 없애고자 했습니다.
되도록이면 기본 설정을 가져가고 기본값만 주는 것으로 형태를 가져갔습니다.

### `badge`컴포넌트

이름을 변경한 부분이 큰 변경 사항인 것 같습니다.
기존에는 `'default', 'channel', 'selectedChannel', 'primary'`을 사용하고 있었는데요.
제 생각에는 도메인의 느낌이 있을 필요가 없는 컴포넌트여서 우선은 차크라 ui를 참고하여 `'outline' | 'solid' | 'subtle'`로 가져가 봤습니다.
지금 `subtle`이 모호한데 우선은 참고해주시기 바랍니다.

### `button` 컴포넌트

많이 쓰일 컴포넌트여서 어디까지 고려해야 하나 고민이 많이 되었는데요.
`theme`에서 기본값으로 `default`는 아무 값이 없어 커스텀할 때 사용하면 될 것 같고 이외에 `main`, `active`가 있습니다.

### `Card` 컴포넌트

`CardTitle` 파일을 삭제했습니다. 차크라 ui를 참고했을 때 `CardBody`가 더 사용하는 입장에서 맞는 것 같더라구요.
해당 부분으로 작업이 이루어지면 좋을 것 같습니다.

### className

className을 추가 props에서 따로 받지 않고 기본 태그 props에서 받는 형태로 변경했습니다.
현재 className에 아무런 값을 주지 않으면 `undefined`로 넘어갑니다.
이 부분이 기능적으로는 문제가 되지는 않는데요. 해결 방법으로는 `classNames`라는 라이브러리를 설치하면 될 것 같지만
또 추가적인 학습이 필요할 것 같아서 우선 안해도 되지 않을까라는 생각을 하게 되었습니다.

### chromatic

스토리북 배포를 진행해봤습니다. 포크한 저장소 기준으로 최신화가 이루어지는 것 같아서 계속 만져보고 관련 설정 더 진행하겠습니다.
패키지가 추가되어서 `npm install` 해주세요!

## 궁금한 점

## 이슈 번호

- close #113 

<!--## 테스트 계획 또는 완료 사항-->
