### PR TITLE
스토리북 toast 컴포넌트 관련 작업

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,9 +1,11 @@
 import type { Preview } from '@storybook/react';
+import React from 'react';
 
 import { withThemeByClassName } from '@storybook/addon-styling';
 
 /* TODO: update import to your tailwind styles file. If you're using Angular, inject this through your angular.json config instead */
 import '../src/styles/index.css';
+import { ToastProvider } from '../src/components/common/Toast';
 
 const preview: Preview = {
   parameters: {
@@ -19,6 +21,11 @@ const preview: Preview = {
   decorators: [
     // Adds theme switching support.
     // NOTE: requires setting "darkMode" to "class" in your tailwind config
+    (Story) => (
+      <ToastProvider>
+        <Story />
+      </ToastProvider>
+    ),
     withThemeByClassName({
       themes: {
         light: 'light',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
+import { ToastProvider } from './components/common';
 import { router } from '~/routes';
 
 const queryClient: QueryClient = new QueryClient({
@@ -10,7 +11,9 @@ const queryClient: QueryClient = new QueryClient({
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ToastProvider>
+        <RouterProvider router={router} />
+      </ToastProvider>
       <ReactQueryDevtools initialIsOpen />
     </QueryClientProvider>
   );

--- a/src/components/common/Toast/README.md
+++ b/src/components/common/Toast/README.md
@@ -1,0 +1,26 @@
+# Toast 컴포넌트
+
+- `React.Portal`을 사용합니다.
+- `Context API`를 활용한 `Provider` 패턴을 사용합니다.
+
+## 사용법
+
+`useToast` 훅을 통해 Toast와 관련된 기능을 불러옵니다.
+
+```tsx
+const { 사용 메서드 } = useToast();
+```
+
+## 파일 역할
+
+### ToastProvider
+
+모든 토스트들을 렌더링하고 관리하는 역할을 합니다.
+
+### ToastContainer
+
+토스트를 배치하고 순서대로 렌더링하는 역할을 합니다.
+
+### Toast
+
+사용되는 토스트 컴포넌트입니다.

--- a/src/components/common/Toast/Toast.stories.tsx
+++ b/src/components/common/Toast/Toast.stories.tsx
@@ -1,0 +1,15 @@
+import { useToast } from './ToastProvider';
+
+const meta = {
+  title: 'Components/Common/Toast'
+};
+
+export default meta;
+
+export const Default = () => {
+  const { addToast } = useToast();
+
+  return (
+    <button onClick={() => addToast({ content: 'Toast!' })}>Add Toast</button>
+  );
+};

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -9,9 +9,12 @@ const Toast = ({ id, children }: ToastProps) => {
   const { removeToast } = useToast();
 
   return (
-    <div id={id}>
+    <div
+      id={id}
+      className="absolute right-0 flex flex-col rounded-[0.625rem] border-[1.5px] px-12 py-2"
+    >
       {children}
-      <button onClick={() => removeToast({ id })}>삭제!</button>
+      <button onClick={() => removeToast({ id })}>삭제</button>
     </div>
   );
 };

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -1,0 +1,19 @@
+import { useToast } from './ToastProvider';
+
+interface ToastProps {
+  id: string;
+  children: React.ReactNode;
+}
+
+const Toast = ({ id, children }: ToastProps) => {
+  const { removeToast } = useToast();
+
+  return (
+    <div id={id}>
+      {children}
+      <button onClick={() => removeToast({ id })}>삭제!</button>
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -11,10 +11,12 @@ const Toast = ({ id, children }: ToastProps) => {
   return (
     <div
       id={id}
-      className="absolute right-0 flex flex-col rounded-[0.625rem] border-[1.5px] px-12 py-2"
+      className="flex flex-col rounded-[0.625rem] border-[1.5px] px-12 py-2"
     >
-      {children}
-      <button onClick={() => removeToast({ id })}>삭제</button>
+      <div>
+        {children}
+        <button onClick={() => removeToast({ id })}>삭제</button>
+      </div>
     </div>
   );
 };

--- a/src/components/common/Toast/ToastContainer.tsx
+++ b/src/components/common/Toast/ToastContainer.tsx
@@ -1,0 +1,21 @@
+import { createPortal } from 'react-dom';
+import Toast from './Toast';
+
+export interface ToastContainerProps {
+  toasts: { id: string; content: string }[];
+}
+
+const ToastContainer = ({ toasts }: ToastContainerProps) => {
+  return createPortal(
+    <div className="absolute right-0 top-0">
+      {toasts.map((toast) => (
+        <Toast key={toast.id} id={toast.id}>
+          {toast.content}
+        </Toast>
+      ))}
+    </div>,
+    document.body
+  );
+};
+
+export default ToastContainer;

--- a/src/components/common/Toast/ToastProvider.tsx
+++ b/src/components/common/Toast/ToastProvider.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState } from 'react';
+import ToastContainer from './ToastContainer';
+import { generateRandomId } from './util';
+
+interface ToastContextType {
+  addToast: ({ content }: { content: string }) => void;
+  removeToast: ({ id }: { id: string }) => void;
+}
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+export const useToast = () => {
+  const toast = useContext(ToastContext);
+
+  if (!toast) {
+    throw new Error('useToast는 ToastProvider 내부에서 사용해야 합니다!');
+  }
+
+  return toast;
+};
+
+const ToastProvider = ({ children }: React.PropsWithChildren) => {
+  const [toasts, setToasts] = useState<{ id: string; content: string }[]>([]);
+
+  const addToast = ({ content }: { content: string }) => {
+    setToasts((prev) => [...prev, { id: generateRandomId(), content }]);
+  };
+
+  const removeToast = ({ id }: { id: string }) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  };
+
+  return (
+    <ToastContext.Provider value={{ addToast, removeToast }}>
+      <ToastContainer toasts={toasts} />
+      {children}
+    </ToastContext.Provider>
+  );
+};
+
+export default ToastProvider;

--- a/src/components/common/Toast/index.ts
+++ b/src/components/common/Toast/index.ts
@@ -1,0 +1,1 @@
+export { default as ToastProvider, useToast } from './ToastProvider';

--- a/src/components/common/Toast/util.ts
+++ b/src/components/common/Toast/util.ts
@@ -1,0 +1,3 @@
+export const generateRandomId = () => {
+  return Math.random().toString(36).substring(2, 12);
+};

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -4,3 +4,4 @@ export * from './Avatar';
 export * from './Cards';
 export * from './Badge';
 export * from './Image';
+export * from './Toast';

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -173,7 +173,7 @@ const HomePage = () => {
         </div>
       </div>
 
-      <div className="no-scrollbar absolute left-1/2 top-48 w-full -translate-x-1/2 overflow-x-scroll">
+      <div className="absolute left-1/2 top-48 w-full -translate-x-1/2 overflow-x-scroll no-scrollbar">
         <ul className="inline-flex gap-3 px-6">
           {MOCK_CHANNEL.map(({ id, channelName, updatedAt, decription }) => (
             <li


### PR DESCRIPTION
## 구현 내용

기본 토스트 기능 구현 작업 진행했습니다.
스타일은 나중에 진행될 것 같네요.

`useToast` 훅을 사용하면 됩니다.

<!-- ## 스크린샷 -->

https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/79239852/c765f53e-137f-416d-be5c-95f35a299e61

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

`useToast`를 불러오는 경로에서 고민 좀 많이 했네요.
일반적으로는 `hooks` 폴더가 맞는 것 같은데 `Conetxt API` 타입과 관련해서 어디서 구성해야 할지 생각이 많아지게 되네요.
우선 그냥 `Toast` 폴더 내에 모아두는 형태로 했습니다.

## 궁금한 점

## 이슈 번호

- close #29 

<!--## 테스트 계획 또는 완료 사항-->
