### PR TITLE
getRelativeTIme 함수 추가

### DIFF
--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, List, ListItem } from '~/components';
+import { Button, Input } from '~/components/common';
 import { useAuth, useForm } from '~/hooks';
 
 const SignupPage = () => {

--- a/src/utils/getRelativeTime.ts
+++ b/src/utils/getRelativeTime.ts
@@ -1,0 +1,23 @@
+import dayjs from 'dayjs';
+
+const getRelativeTime = (targetTime: string) => {
+  const currentTime = dayjs();
+  const targetDateTime = dayjs(targetTime);
+
+  const daysDiff = currentTime.diff(targetDateTime, 'day');
+  const hoursDiff = currentTime.diff(targetDateTime, 'hour');
+  const minutesDiff = currentTime.diff(targetDateTime, 'minute');
+  const secondsDiff = currentTime.diff(targetDateTime, 'second');
+
+  if (daysDiff > 0) {
+    return `${daysDiff}일 전`;
+  } else if (hoursDiff > 0) {
+    return `${hoursDiff}시간 전`;
+  } else if (minutesDiff > 0) {
+    return `${minutesDiff}분 전`;
+  }
+
+  return `${secondsDiff}초 전`;
+};
+
+export default getRelativeTime;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as getRelativeTime } from './getRelativeTime';


### PR DESCRIPTION
## 구현 내용

<img width="745" alt="스크린샷 2023-09-18 오후 3 14 49" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/2cf7eec8-5ec1-47b7-8441-bfe6c6f1a148">

api 요청을 통해 받아온 하나의 포스트나 댓글 정보에는 위와 같은 createdAt이나 updatedAt 시간이 있습니다.
2개의 값 중 하나를 사용해 `1시간 전`,`1일 전` 같은 상대 시간을 구할 수 있는 함수입니다.

```
ex
let time = 2023-09-11T15:36:38.213Z;

getRelativeTime(time); // 6일 전

```

## 이슈 번호

- close #133 

<!--## 테스트 계획 또는 완료 사항-->
