### PR TITLE
프로필 설정 페이지 추가 및 기능 구현

### DIFF
--- a/src/components/common/Modal/CheckForm.tsx
+++ b/src/components/common/Modal/CheckForm.tsx
@@ -1,0 +1,37 @@
+import { Button } from '../Buttons';
+
+interface CheckFormProps {
+  content: string;
+  handleCancel: () => void;
+  handleAgree: () => void;
+}
+
+const CheckForm = ({ content, handleCancel, handleAgree }: CheckFormProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <div>{content}</div>
+      <div className="flex gap-6">
+        <Button
+          theme="main"
+          size="sm"
+          variant="outline"
+          className="px-10 py-2"
+          onClick={handleCancel}
+        >
+          취소
+        </Button>
+        <Button
+          theme="main"
+          size="sm"
+          variant="solid"
+          className="px-10 py-2"
+          onClick={handleAgree}
+        >
+          확인
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default CheckForm;

--- a/src/components/common/Modal/index.ts
+++ b/src/components/common/Modal/index.ts
@@ -1,2 +1,3 @@
 export { default as Modal } from './Modal';
 export { default as LoginForm } from './LoginForm';
+export { default as CheckForm } from './CheckForm';

--- a/src/pages/ProfileEditPage/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage/ProfileEditPage.tsx
@@ -1,5 +1,19 @@
+import { ProfileFullName, ProfilePassword, ProfileSignOut } from './components';
+import { Header } from '~/components/domain';
+
 const ProfileEditPage = () => {
-  return <div />;
+  return (
+    <>
+      <Header leftArea="left-arrow" rightArea={false}>
+        프로필 설정
+      </Header>
+      <div className="flex h-screen flex-col gap-12 bg-gray-50 p-5">
+        <ProfileFullName />
+        <ProfilePassword />
+        <ProfileSignOut />
+      </div>
+    </>
+  );
 };
 
 export default ProfileEditPage;

--- a/src/pages/ProfileEditPage/components/ProfileEditInput.tsx
+++ b/src/pages/ProfileEditPage/components/ProfileEditInput.tsx
@@ -1,0 +1,12 @@
+const ProfileEditInput = (
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) => {
+  return (
+    <input
+      {...props}
+      className="w-24 flex-1 bg-transparent p-2 focus:outline-main-base"
+    />
+  );
+};
+
+export default ProfileEditInput;

--- a/src/pages/ProfileEditPage/components/ProfileEditLabel.tsx
+++ b/src/pages/ProfileEditPage/components/ProfileEditLabel.tsx
@@ -1,0 +1,15 @@
+const ProfileEditLabel = ({
+  htmlFor,
+  children
+}: React.LabelHTMLAttributes<React.PropsWithChildren>) => {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className="mr-5 w-12 text-center text-xs text-gray-400"
+    >
+      {children}
+    </label>
+  );
+};
+
+export default ProfileEditLabel;

--- a/src/pages/ProfileEditPage/components/ProfileEditLabel.tsx
+++ b/src/pages/ProfileEditPage/components/ProfileEditLabel.tsx
@@ -1,12 +1,9 @@
 const ProfileEditLabel = ({
-  htmlFor,
-  children
-}: React.LabelHTMLAttributes<React.PropsWithChildren>) => {
+  children,
+  ...props
+}: React.LabelHTMLAttributes<HTMLLabelElement>) => {
   return (
-    <label
-      htmlFor={htmlFor}
-      className="mr-5 w-12 text-center text-xs text-gray-400"
-    >
+    <label className="mr-5 w-12 text-center text-xs text-gray-400" {...props}>
       {children}
     </label>
   );

--- a/src/pages/ProfileEditPage/components/ProfileEditWrapper.tsx
+++ b/src/pages/ProfileEditPage/components/ProfileEditWrapper.tsx
@@ -1,0 +1,14 @@
+const ProfileEditWrapper = ({
+  children,
+  className
+}: React.HTMLAttributes<React.PropsWithChildren>) => {
+  return (
+    <div
+      className={`flex w-full items-center border-b-2 border-gray-200 py-3 ${className}`}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default ProfileEditWrapper;

--- a/src/pages/ProfileEditPage/components/ProfileFullName.tsx
+++ b/src/pages/ProfileEditPage/components/ProfileFullName.tsx
@@ -17,7 +17,7 @@ const ProfileFullName = () => {
     setFullName(e.currentTarget.value);
   };
 
-  const handleEditFullName = async () => {
+  const handleFullNameEdit = async () => {
     await snsApiClient.put('/settings/update-user', {
       fullName
     });
@@ -29,7 +29,7 @@ const ProfileFullName = () => {
       <Modal handleClose={closeModal} modalOpened={modalOpened}>
         <CheckForm
           content="닉네임을 변경하시겠습니까?"
-          handleAgree={handleEditFullName}
+          handleAgree={handleFullNameEdit}
           handleCancel={closeModal}
         />
       </Modal>

--- a/src/pages/ProfileEditPage/components/ProfileFullName.tsx
+++ b/src/pages/ProfileEditPage/components/ProfileFullName.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import ProfileEditInput from './ProfileEditInput';
+import ProfileEditLabel from './ProfileEditLabel';
+import ProfileEditWrapper from './ProfileEditWrapper';
+import { snsApiClient } from '~/api';
+import { Button, CheckForm, Modal } from '~/components/common';
+import { useModal, useUser } from '~/hooks';
+
+const ProfileFullName = () => {
+  const { user } = useUser();
+  const { modalOpened, openModal, closeModal } = useModal();
+  const [fullName, setFullName] = useState(user?.fullName);
+
+  const handleFullNameChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setFullName(e.currentTarget.value);
+  };
+
+  const handleEditFullName = async () => {
+    await snsApiClient.put('/settings/update-user', {
+      fullName
+    });
+    closeModal();
+  };
+
+  return (
+    <div>
+      <Modal handleClose={closeModal} modalOpened={modalOpened}>
+        <CheckForm
+          content="닉네임을 변경하시겠습니까?"
+          handleAgree={handleEditFullName}
+          handleCancel={closeModal}
+        />
+      </Modal>
+      <div>내 계정</div>
+      <ProfileEditWrapper>
+        <ProfileEditLabel htmlFor="fullName">닉네임</ProfileEditLabel>
+        <ProfileEditInput
+          id="fullName"
+          value={fullName}
+          onChange={handleFullNameChange}
+        />
+        <Button
+          theme="main"
+          size="sm"
+          variant="solid"
+          className="px-4 py-2"
+          onClick={openModal}
+        >
+          변경하기
+        </Button>
+      </ProfileEditWrapper>
+    </div>
+  );
+};
+
+export default ProfileFullName;

--- a/src/pages/ProfileEditPage/components/ProfilePassword.tsx
+++ b/src/pages/ProfileEditPage/components/ProfilePassword.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import ProfileEditInput from './ProfileEditInput';
+import ProfileEditLabel from './ProfileEditLabel';
+import ProfileEditWrapper from './ProfileEditWrapper';
+import { snsApiClient } from '~/api';
+import { EyeOffIcon, EyeOnIcon } from '~/assets';
+import { Button, CheckForm, Modal } from '~/components/common';
+import { useForm, useModal } from '~/hooks';
+
+const ProfilePassword = () => {
+  const [password, handlePassword] = useForm();
+  const [passwordCheck, handlePasswordCheck] = useForm();
+  const [showPassword, setShowPassword] = useState(false);
+  const { modalOpened, openModal, closeModal } = useModal();
+
+  const handleEditPassword = async () => {
+    await snsApiClient.put('/settings/update-password', {
+      password
+    });
+    closeModal();
+  };
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+      }}
+    >
+      <Modal handleClose={closeModal} modalOpened={modalOpened}>
+        <CheckForm
+          content="비밀번호를 변경하시겠습니까?"
+          handleAgree={handleEditPassword}
+          handleCancel={closeModal}
+        />
+      </Modal>
+      <div>비밀번호</div>
+      <ProfileEditWrapper>
+        <ProfileEditLabel htmlFor="password">비밀번호</ProfileEditLabel>
+        <ProfileEditInput
+          id="password"
+          value={password}
+          onChange={handlePassword}
+          type={showPassword ? 'text' : 'password'}
+          autoComplete="new-password"
+        />
+      </ProfileEditWrapper>
+      <ProfileEditWrapper className="relative">
+        <ProfileEditLabel htmlFor="passwordCheck">
+          비밀번호 확인
+        </ProfileEditLabel>
+        <ProfileEditInput
+          id="passwordCheck"
+          value={passwordCheck}
+          onChange={handlePasswordCheck}
+          type={showPassword ? 'text' : 'password'}
+          autoComplete="new-password"
+        />
+        <Button
+          theme="main"
+          size="sm"
+          variant="solid"
+          className="px-4 py-2"
+          onClick={openModal}
+        >
+          변경하기
+        </Button>
+        {showPassword ? (
+          <EyeOnIcon
+            className="absolute right-24"
+            onClick={() => setShowPassword(false)}
+          />
+        ) : (
+          <EyeOffIcon
+            className="absolute right-24"
+            onClick={() => setShowPassword(true)}
+          />
+        )}
+      </ProfileEditWrapper>
+    </form>
+  );
+};
+
+export default ProfilePassword;

--- a/src/pages/ProfileEditPage/components/ProfileSignOut.tsx
+++ b/src/pages/ProfileEditPage/components/ProfileSignOut.tsx
@@ -1,0 +1,39 @@
+import { useNavigate } from 'react-router-dom';
+import { snsApiClient } from '~/api';
+import { RightArrowIcon } from '~/assets';
+import { Button, CheckForm, Modal } from '~/components/common';
+import { useAuth, useModal } from '~/hooks';
+
+const ProfileSignOut = () => {
+  const { signOut } = useAuth();
+  const navigate = useNavigate();
+  const { modalOpened, openModal, closeModal } = useModal();
+
+  const handleLogout = async () => {
+    await snsApiClient.post('/logout');
+    signOut();
+    navigate('/');
+  };
+
+  return (
+    <div>
+      <Modal modalOpened={modalOpened} handleClose={closeModal}>
+        <CheckForm
+          content="로그아웃 하시겠습니까?"
+          handleAgree={handleLogout}
+          handleCancel={closeModal}
+        />
+      </Modal>
+      <div>로그인 관리</div>
+      <div
+        onClick={openModal}
+        className="flex cursor-pointer items-center justify-between"
+      >
+        <button className="mt-3 text-sm text-sub-blue">로그아웃</button>
+        <RightArrowIcon />
+      </div>
+    </div>
+  );
+};
+
+export default ProfileSignOut;

--- a/src/pages/ProfileEditPage/components/ProfileSignOut.tsx
+++ b/src/pages/ProfileEditPage/components/ProfileSignOut.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { snsApiClient } from '~/api';
 import { RightArrowIcon } from '~/assets';
-import { Button, CheckForm, Modal } from '~/components/common';
+import { CheckForm, Modal } from '~/components/common';
 import { useAuth, useModal } from '~/hooks';
 
 const ProfileSignOut = () => {

--- a/src/pages/ProfileEditPage/components/index.ts
+++ b/src/pages/ProfileEditPage/components/index.ts
@@ -1,0 +1,3 @@
+export { default as ProfileFullName } from './ProfileFullName';
+export { default as ProfilePassword } from './ProfilePassword';
+export { default as ProfileSignOut } from './ProfileSignOut';

--- a/src/pages/ProfilePage/ProfileHeader.tsx
+++ b/src/pages/ProfilePage/ProfileHeader.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { PropsWithChildren, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { snsApiClient } from '~/api';
 import { Avatar, Button } from '~/components/common';
 import { useUser } from '~/hooks';
@@ -12,6 +12,7 @@ const InfoBox = ({ children }: PropsWithChildren) => {
 };
 
 const ProfileHeader = () => {
+  const navigate = useNavigate();
   const { user, updateUser } = useUser();
   const { image, posts, followers, following } = user!;
   const inputRef = useRef<HTMLInputElement>(null);
@@ -41,6 +42,10 @@ const ProfileHeader = () => {
       const changedFile = files[0];
       mutation.mutate(changedFile);
     }
+  };
+
+  const handleEditPageClick = () => {
+    navigate('/profile-edit');
   };
 
   return (
@@ -85,8 +90,13 @@ const ProfileHeader = () => {
         </InfoBox>
       </div>
       <div className="mt-9 grid grid-cols-2 gap-7 px-4">
-        <Button theme="main" size="lg" variant="solid">
-          <Link to="/profile-edit">프로필 설정</Link>
+        <Button
+          theme="main"
+          size="lg"
+          variant="solid"
+          onClick={handleEditPageClick}
+        >
+          프로필 설정
         </Button>
         <Button theme="main" size="lg" variant="outline">
           좋아요 목록


### PR DESCRIPTION
## 구현 내용

프로필 설정 페이지의 기능 구현을 완료했습니다!
- [x] 닉네임 변경
- [x] 비밀번호 변경 
- [x] 로그아웃
 

https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/99bebfac-06c7-4334-bbf9-7827c7b7a36a


<!-- ## 스크린샷 -->

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

Modal 컴포넌트의 사이즈 변경이 필요할 것 같습니다!
- Modal의 children 컴포넌트에서 높이 값을 지정하고 Modal은 width값과 padding을 지정
위와 같은 방식으로 변경하면 좋을 것 같습니다.!

## 이슈 번호

- close #167

<!--## 테스트 계획 또는 완료 사항-->
