### PR TITLE
Menu 컴포넌트 구현

### DIFF
--- a/src/components/common/Menu/Menu.tsx
+++ b/src/components/common/Menu/Menu.tsx
@@ -1,0 +1,32 @@
+import { PropsWithChildren } from 'react';
+import { createPortal } from 'react-dom';
+
+interface MenuProps {
+  handleClose: () => void;
+  portalTarget: Element | DocumentFragment;
+  className?: string;
+}
+
+const Menu = ({
+  handleClose,
+  portalTarget,
+  children,
+  className
+}: PropsWithChildren<MenuProps>) => {
+  if (!portalTarget) return null;
+
+  const defaults = 'fixed left-0 top-0 z-30 h-full w-full';
+
+  return (
+    <div className={`${defaults} ${className ?? ''}`} onClick={handleClose}>
+      {createPortal(
+        <ul className="absolute z-40 rounded-lg bg-white py-3 shadow-md">
+          {children}
+        </ul>,
+        portalTarget
+      )}
+    </div>
+  );
+};
+
+export default Menu;

--- a/src/components/common/Menu/Menu.tsx
+++ b/src/components/common/Menu/Menu.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
+import MenuItem from './MenuItem';
 
 interface MenuProps {
   handleClose: () => void;
@@ -28,5 +29,7 @@ const Menu = ({
     </div>
   );
 };
+
+Menu.Item = MenuItem;
 
 export default Menu;

--- a/src/components/common/Menu/MenuItem.tsx
+++ b/src/components/common/Menu/MenuItem.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren } from 'react';
+
+interface MenuItemProps {
+  handleClick?: () => void;
+  className?: string;
+}
+
+const MenuItem = ({
+  children,
+  handleClick = () => {},
+  className
+}: PropsWithChildren<MenuItemProps>) => {
+  const defaults =
+    'px-4 py-1 text-black hover:bg-gray-100 text-gray-500 text-sm';
+
+  return (
+    <li className={`${defaults} ${className ?? ''}`} onClick={handleClick}>
+      {children}
+    </li>
+  );
+};
+
+export default MenuItem;

--- a/src/components/common/Menu/MenuItem.tsx
+++ b/src/components/common/Menu/MenuItem.tsx
@@ -7,7 +7,7 @@ interface MenuItemProps {
 
 const MenuItem = ({
   children,
-  handleClick = () => {},
+  handleClick,
   className
 }: PropsWithChildren<MenuItemProps>) => {
   const defaults =

--- a/src/components/common/Menu/index.ts
+++ b/src/components/common/Menu/index.ts
@@ -1,0 +1,2 @@
+export { default as Menu } from './Menu';
+export { default as MenuItem } from './MenuItem';

--- a/src/components/common/Menu/index.ts
+++ b/src/components/common/Menu/index.ts
@@ -1,2 +1,1 @@
 export { default as Menu } from './Menu';
-export { default as MenuItem } from './MenuItem';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -7,3 +7,4 @@ export * from './Image';
 export * from './HorizontalScroll';
 export * from './Modal';
 export * from './Toast';
+export * from './Menu';

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,15 +1,16 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 function useModal() {
   const [modalOpened, setModalOpened] = useState(false);
 
-  const openModal = () => {
+  const openModal = useCallback(() => {
+    if (modalOpened) return;
     setModalOpened(true);
-  };
+  }, [modalOpened]);
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setModalOpened(false);
-  };
+  }, []);
 
   return {
     modalOpened,

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -2,8 +2,7 @@ import { useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChannelInfo, ChannelList } from './components';
 import { CHANNELS } from './constants';
-import { HorizontalScroll } from '~/components/common';
-import { Menu, MenuItem } from '~/components/common';
+import { HorizontalScroll, Menu } from '~/components/common';
 import { Header, PostCard } from '~/components/domain';
 import { PostList } from '~/components/domain';
 import { useModal } from '~/hooks';
@@ -80,13 +79,13 @@ const HomePage = () => {
       />
       {modalOpened && (
         <Menu portalTarget={buttonRef.current!} handleClose={closeModal}>
-          <MenuItem handleClick={navigateToHelpChannel}>
+          <Menu.Item handleClick={navigateToHelpChannel}>
             도와주세요 채널로
-          </MenuItem>
-          <MenuItem>메뉴2</MenuItem>
-          <MenuItem>메뉴3</MenuItem>
-          <MenuItem>메뉴4</MenuItem>
-          <MenuItem>메뉴5</MenuItem>
+          </Menu.Item>
+          <Menu.Item>메뉴2</Menu.Item>
+          <Menu.Item>메뉴3</Menu.Item>
+          <Menu.Item>메뉴4</Menu.Item>
+          <Menu.Item>메뉴5</Menu.Item>
         </Menu>
       )}
     </div>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -3,14 +3,19 @@ import { useNavigate } from 'react-router-dom';
 import { ChannelInfo, ChannelList } from './components';
 import { CHANNELS } from './constants';
 import { HorizontalScroll } from '~/components/common';
+import { Menu, MenuItem } from '~/components/common';
 import { Header, PostCard } from '~/components/domain';
 import { PostList } from '~/components/domain';
+import { useModal } from '~/hooks';
 import { useGetChannels, useGetPosts } from '~/services';
 import { getRandomItem } from '~/utils';
 
 const HomePage = () => {
   const navigate = useNavigate();
   const dragStateRef = useRef(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const { modalOpened, openModal, closeModal } = useModal();
 
   const randomChannelKey = getRandomItem(Object.keys(CHANNELS));
   const randomChannel = CHANNELS[randomChannelKey as keyof typeof CHANNELS];
@@ -20,6 +25,10 @@ const HomePage = () => {
     channelId: randomChannel.id,
     limit: 6
   });
+
+  const navigateToHelpChannel = () => {
+    navigate('/channels/help');
+  };
 
   const handleChannelClick = (name: keyof typeof CHANNELS) => {
     if (dragStateRef.current) return;
@@ -53,6 +62,14 @@ const HomePage = () => {
         />
       </HorizontalScroll>
 
+      <button
+        className="mt-24 rounded-xl bg-pink-400 p-4 text-white"
+        ref={buttonRef}
+        onClick={openModal}
+      >
+        여기 클릭해보셈
+      </button>
+
       <PostList
         title="추천글 보기"
         posts={posts}
@@ -61,6 +78,17 @@ const HomePage = () => {
           <PostCard {...post} handleClick={() => console.log(post._id)} />
         )}
       />
+      {modalOpened && (
+        <Menu portalTarget={buttonRef.current!} handleClose={closeModal}>
+          <MenuItem handleClick={navigateToHelpChannel}>
+            도와주세요 채널로
+          </MenuItem>
+          <MenuItem>메뉴2</MenuItem>
+          <MenuItem>메뉴3</MenuItem>
+          <MenuItem>메뉴4</MenuItem>
+          <MenuItem>메뉴5</MenuItem>
+        </Menu>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 구현 내용

`Menu`, `MenuItem` 컴포넌트를 구현했습니다.

<img src='https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/97094709/58090b5e-8e33-468d-90d4-633ac436ebcb' width='600' />


## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

### 사용 방법

먼저 사용할 페이지 파일에 `useModal`를 활용하여 모달 상태를 저장합니다.
그리고 해당 메뉴 컴포넌트의 위치를 정하기 위해 기준이 될 컴포넌트를 `useRef`로 참조해야 합니다.

```tsx
const { modalOpened, openModal, closeModal } = useModal();
const elementRef = useRef<HTML타입Element>(null);
```

<br>

사용하는 부분은 간단합니다.

```html
{/* useRef로 참조할 DOM 요소 */}
<div ref={elementRef}>기준 위치</div>

<Menu portalTarget={elementRef.current!} handleClose={closeModal}>
  <MenuItem handleClick={navigateToHelpChannel}>
    도와주세요 채널로
  </MenuItem>
  <MenuItem>메뉴2</MenuItem>
  <MenuItem>메뉴3</MenuItem>
  <MenuItem>메뉴4</MenuItem>
  <MenuItem>메뉴5</MenuItem>
</Menu>
```

- `Menu`: portalTarget과 handleClose를 prop으로 받습니다. protalTarget은 현재 useRef로 참조하고 있는 DOM을 뜻합니다. handleClose에는 useModal로 받았던 closeModal 함수를 전해줍니다.

- `MenuItem`: 여기에는 개별 메뉴 아이템이 들어갑니다. `handleClick`에 클릭 이벤트 함수를 전달해줄 수 있습니다.

<br>

### `useModal` 최적화

```ts
const openModal = useCallback(() => {
  if (modalOpened) return;
  setModalOpened(true);
}, [modalOpened]);

const closeModal = useCallback(() => {
  setModalOpened(false);
}, []);
```

사용하는 함수에 전부 useCallback을 씌워줬습니다!

## 궁금한 점

더 깔끔하게 작성할 수 있는 방법이 있을지 궁금하네요!

## 이슈 번호

- close #189 

<!--## 테스트 계획 또는 완료 사항-->
