### PR TITLE
프록시를 통한 엔드포인트 숨기기

### DIFF
--- a/src/api/snsApiClient.ts
+++ b/src/api/snsApiClient.ts
@@ -1,10 +1,8 @@
 import axios from 'axios';
 import { getStoredData } from '~/utils/userStorage';
 
-const { VITE_API_END_POINT } = import.meta.env;
-
 export const snsApiClient = axios.create({
-  baseURL: VITE_API_END_POINT
+  baseURL: '/api'
 });
 
 snsApiClient.interceptors.request.use((config) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,26 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import svgr from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react(), svgr()],
-  resolve: {
-    alias: [{ find: '~', replacement: path.resolve(__dirname, 'src') }]
-  }
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const { VITE_API_END_POINT } = env;
+
+  return {
+    plugins: [react(), svgr()],
+    resolve: {
+      alias: [{ find: '~', replacement: path.resolve(__dirname, 'src') }]
+    },
+    server: {
+      proxy: {
+        '/api': {
+          target: VITE_API_END_POINT,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, '')
+        }
+      }
+    }
+  };
 });


### PR DESCRIPTION
## 구현 내용

vite proxy 설정을 통해 api 엔드포인트를 숨겼습니다.

![image](https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/97094709/db51493d-78ce-4677-9768-34d037bd5912)

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->

```ts
// vite.config.ts에 추가된 부분

server: {
  proxy: {
    '/api': {
      target: VITE_API_END_POINT,
      changeOrigin: true,
      rewrite: (path) => path.replace(/^\/api/, '')
    }
  }
}
```

### `proxy`

Vite 개발 서버에서 사용하는 설정 객체입니다. 이 설정을 사용하면 개발 중에 프론트엔드 애플리케이션에서 백엔드 API로 요청을 보낼 때, 개발 서버를 중간에 거쳐 백엔드 서버로 요청을 프록시(proxy)할 수 있습니다.

### `target`

target은 프록시 대상 서버를 지정합니다. 이 설정을 통해 요청이 개발 서버를 거쳐 백엔드 서버로 전달됩니다.

### `changeOrigin`

요청의 origin(origin은 URL의 프로토콜, 호스트, 포트 등을 나타내는 부분)을 대상 서버의 origin으로 변경하도록 지시합니다. 이 설정을 통해 CORS(Cross-Origin Resource Sharing) 문제를 해결할 수 있습니다.

### `rewrite`

rewrite 함수는 요청 경로를 변경할 때 사용됩니다. 이 함수는 요청 경로의 앞부분 '/api'를 제거하고 변경된 경로를 반환합니다. 이것은 개발 서버에서 '/api'를 제외하고 백엔드 서버로 요청을 전달하기 위해 사용됩니다.

예를 들어, 프론트엔드 애플리케이션에서 '/api/users'로 요청을 보내면, 개발 서버는 이 요청을 `VITE_API_END_POINT`로 설정된 백엔드 서버의 '/users' 경로로 프록시하게 됩니다.

## 이슈 번호

- close #196 
