### PR TITLE
Postlist 버그 수정

### DIFF
--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -3,28 +3,28 @@ import { useEffect, useRef } from 'react';
 
 interface UseInfiniteScrollProps<T> {
   fetchData: (pageParam: number) => Promise<T[]>;
+  queryKey: string;
 }
 
-const useInfiniteScroll = <T>({ fetchData }: UseInfiniteScrollProps<T>) => {
+const useInfiniteScroll = <T>({
+  fetchData,
+  queryKey
+}: UseInfiniteScrollProps<T>) => {
   const {
     data = { pages: [], pageParams: [] },
     hasNextPage,
     fetchNextPage
-  } = useInfiniteQuery(['posts'], ({ pageParam = 0 }) => fetchData(pageParam), {
-    getNextPageParam: (lastPage, allPages) => {
-      if (lastPage.length === 0) {
-        return undefined;
+  } = useInfiniteQuery(
+    ['posts', queryKey],
+    ({ pageParam = 0 }) => fetchData(pageParam),
+    {
+      getNextPageParam: (lastPage, allPages) => {
+        return lastPage.length === 0
+          ? undefined
+          : allPages.reduce((total, page) => total + page.length, 0);
       }
-
-      let count = 0;
-
-      allPages.forEach((page) => {
-        count += page.length;
-      });
-
-      return count;
     }
-  });
+  );
 
   const ref = useRef<HTMLDivElement | null>(null);
 

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -16,12 +16,19 @@ const HomePage = () => {
 
   const { modalOpened, openModal, closeModal } = useModal();
 
-  const randomChannelKey = getRandomItem(Object.keys(CHANNELS));
-  const randomChannel = CHANNELS[randomChannelKey as keyof typeof CHANNELS];
+  const randomChannelRef = useRef<
+    (typeof CHANNELS)[keyof typeof CHANNELS] | null
+  >(null);
+
+  if (randomChannelRef.current === null) {
+    const randomChannelKey = getRandomItem(Object.keys(CHANNELS));
+    randomChannelRef.current =
+      CHANNELS[randomChannelKey as keyof typeof CHANNELS];
+  }
 
   const { data: channels } = useGetChannels();
   const { data: posts, ref } = useGetPosts({
-    channelId: randomChannel.id,
+    channelId: randomChannelRef.current.id,
     limit: 6
   });
 

--- a/src/pages/channelPage/ChannelPage.tsx
+++ b/src/pages/channelPage/ChannelPage.tsx
@@ -16,7 +16,7 @@ const ChannelPage = () => {
   });
 
   return (
-    <div className="h-full overflow-y-scroll">
+    <div className="h-full overflow-y-auto bg-gray-100">
       <Header leftArea="left-arrow">{CHANNELS[channel].title}</Header>
       <PostList
         ref={ref}

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -175,7 +175,8 @@ export const useUnLikePost = () => {
 
 export const useGetPosts = ({ channelId, limit }: Omit<GetPosts, 'offset'>) => {
   return useInfiniteScroll({
-    fetchData: (pageParam) => getPosts({ channelId, limit, offset: pageParam })
+    fetchData: (pageParam) => getPosts({ channelId, limit, offset: pageParam }),
+    queryKey: channelId
   });
 };
 


### PR DESCRIPTION
## 구현 내용

### PostList를 사용하는 컴포넌트 페이지에 진입 시 이전 채널의 Post들이 남아있어 잠깐 출력되는 문제를 해결

<img width="378" alt="스크린샷 2023-09-24 오후 5 58 39" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/d2d2eb05-80af-4ffa-aab2-c2004d09a064">

useInfiniteScroll에서 querykey 값을 추가해 문제를 해결했습니다.
이런 방식으로 하면 `자유 채널 => 도와주세요 채널 => 자유 채널` 같은 방식으로 채널을 이동해도 자유 채널에서는 자유 채널의 캐시 값만 보이고 도와주세요 채널에는 자유 채널의 캐시값이 보이지 않습니다.

```
getNextPageParam: (lastPage, allPages) => {
        return lastPage.length === 0
          ? undefined
          : allPages.reduce((total, page) => total + page.length, 0);
      }
```
추가적으로 getNextPageParam 부분의 반환 부분을 간결하게 정리했습니다.

### HomePage의 랜덤 채널 방식 변경

- 기본에는 홈페이지 로딩 시 랜덤 채널이 데이터 상태가 변경되는 경우 계속해서 변경되었습니다.

https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/bf25fd1b-589c-431a-873d-7bb9e90fa67a

- ref를 사용해서 랜덤 채널이 한번만 선택되도록 변경하였습니다. 제가 홈페이지쪽은 어떤 방식인지 잘 몰라서 수정하긴했는데 만약 의도된 것이라면 로직을 다시 수정하도록 하겠습니다.

https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/8a72358e-55d3-428f-814c-8a5d9717e082

### 채널 페이지 bg값 적용

- 무한 스크롤이 적용하고 다음 페이지를 불러올 경우 해당 부분은 bg 값이 적용되지 않았습니다.

<img width="923" alt="스크린샷 2023-09-24 오후 5 46 23" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/ccfe7b18-f8e9-4c4f-9484-6b3751b985d6">

-  아래와 같이 수정하였습니다.

<img width="941" alt="스크린샷 2023-09-24 오후 5 55 26" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/b1f82563-33a1-405b-b36c-08c6a8aa8e8f">

하나의 페이지를 감싸고 있는 컴포넌트에서 bg 값을 적용하면 됩니다!...

<img width="602" alt="스크린샷 2023-09-24 오후 6 13 14" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/23c56e4e-29db-4a67-9e7a-0044d50617fd">

## 이슈 번호

- close #216 

<!--## 테스트 계획 또는 완료 사항-->
