### PR TITLE
feat: Header 컴포넌트 로그인 상태에 따른 아이콘 표시 및 navigate 수정

### DIFF
--- a/src/components/domain/Header/Header.tsx
+++ b/src/components/domain/Header/Header.tsx
@@ -1,7 +1,7 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { BellIcon, LeftArrowIcon, SearchIcon } from '~/assets';
 import { Badge, Button } from '~/components/common';
-import { useUserNotifications } from '~/hooks';
+import { useUser, useUserNotifications } from '~/hooks';
 
 interface HeaderProps {
   leftArea?: 'home' | 'left-arrow';
@@ -15,13 +15,10 @@ const Header = ({
 }: React.PropsWithChildren<HeaderProps>) => {
   const navigate = useNavigate();
   const notification = useUserNotifications();
+  const { user } = useUser();
 
   const handleGoBack = () => {
     navigate(-1);
-  };
-
-  const handleGoToPage = (path: 'search' | 'notifications') => {
-    navigate(path);
   };
 
   return (
@@ -40,25 +37,21 @@ const Header = ({
         </Button>
       )}
       {rightArea && (
-        <>
-          <Button
-            className="absolute right-16 top-[3.75rem] flex h-6 w-6 items-center justify-start cs:p-0"
-            onClick={() => handleGoToPage('search')}
-          >
+        <div className="absolute right-6 top-[3.75rem] flex gap-4">
+          <Link to="/search">
             <SearchIcon className="h-6 w-6 stroke-white" />
-          </Button>
-          <Button
-            className="absolute right-6 top-[3.75rem] flex h-6 w-6 items-center justify-start cs:p-0"
-            onClick={() => handleGoToPage('notifications')}
-          >
-            <BellIcon className="h-6 w-6 stroke-white" />
-          </Button>
-          {notification.length > 0 && (
-            <Badge className="absolute right-6 top-[3.1rem] flex translate-x-1/4 translate-y-1/4 items-center justify-center border-none text-[10px] text-white cs:bg-active-base cs:px-1 cs:py-0">
-              {notification.length}
-            </Badge>
+          </Link>
+          {user && (
+            <Link to="/notifications">
+              <BellIcon className="h-6 w-6 stroke-white" />
+              {notification.length > 0 && (
+                <Badge className="absolute -top-1 right-[6px] flex translate-x-1/2 items-center justify-center border-none text-[10px] text-white cs:bg-active-base cs:px-1 cs:py-0">
+                  {notification.length}
+                </Badge>
+              )}
+            </Link>
           )}
-        </>
+        </div>
       )}
     </header>
   );


### PR DESCRIPTION
## 구현 내용

로그인 상태에 따라서 알림 아이콘이 보이거나 보이지 않도록 수정했습니다.

- 로그인 한 경우
  <img width="731" alt="스크린샷 2023-09-25 오전 12 16 07" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/6b6bb18f-206d-4dc9-93fa-1c2dfd2d0c53">

- 로그아웃 한 경우(로그인 상태가 아닐때)
  <img width="736" alt="스크린샷 2023-09-25 오전 12 16 24" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/17055e79-cb50-4b56-98d8-994ea95759ca">

Link 태그를 적용해서 홈페이지가 아닌 다른 페이지에서 이동 시 발생하던 url 문제를 해결했습니다.

<img width="284" alt="스크린샷 2023-09-25 오전 12 18 14" src="https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/8db299ad-99ae-4e5e-960b-954ff0a8dedd">

## 이슈 번호

- close #221 

<!--## 테스트 계획 또는 완료 사항-->
