### PR TITLE
로그인 실패 시 토스트 띄워주기

### DIFF
--- a/src/components/common/Modal/LoginForm.tsx
+++ b/src/components/common/Modal/LoginForm.tsx
@@ -2,6 +2,7 @@ import { useState, ChangeEvent, FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { EyeOffIcon, EyeOnIcon } from '~/assets';
 import { Input, Button } from '~/components/common';
+import { useToast } from '~/components/common';
 import { useAuth } from '~/hooks';
 import { isValidEmail, isValidPassword, isValidSignIn } from '~/utils';
 interface LoginFormProps {
@@ -9,6 +10,7 @@ interface LoginFormProps {
 }
 
 const LoginForm = ({ handleClose }: LoginFormProps) => {
+  const { addToast } = useToast();
   const { signIn } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -21,13 +23,13 @@ const LoginForm = ({ handleClose }: LoginFormProps) => {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    /**
-    로그인 처리 로직 예시:
-    API 호출 또는 상태 업데이트 등
-    로그인 성공 시 onSubmit을 호출하여 모달을 닫을 수 있음
-    */
-    await signIn({ email, password });
-    handleClose();
+
+    try {
+      await signIn({ email, password });
+      handleClose();
+    } catch (error) {
+      addToast({ content: '이메일 혹은 비밀번호를 잘못 입력했습니다.' });
+    }
   };
 
   const handleChangeEmail = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/common/Modal/LoginForm.tsx
+++ b/src/components/common/Modal/LoginForm.tsx
@@ -28,7 +28,11 @@ const LoginForm = ({ handleClose }: LoginFormProps) => {
       await signIn({ email, password });
       handleClose();
     } catch (error) {
-      addToast({ content: '이메일 혹은 비밀번호를 잘못 입력했습니다.' });
+      if (error instanceof Error) {
+        addToast({ content: error.message });
+      }
+
+      throw new Error('알 수 없는 에러가 발생했습니다.');
     }
   };
 

--- a/src/components/common/Toast/ToastContainer.tsx
+++ b/src/components/common/Toast/ToastContainer.tsx
@@ -7,7 +7,7 @@ export interface ToastContainerProps {
 
 const ToastContainer = ({ toasts }: ToastContainerProps) => {
   return createPortal(
-    <div className="absolute right-0 top-0">
+    <div className="absolute right-0 top-0 z-50">
       {toasts.map((toast) => (
         <Toast key={toast.id} id={toast.id}>
           {toast.content}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -23,8 +23,6 @@ const useAuth = () => {
       const { data, status } = await snsApiClient.post(urlEndpoint, authInfo);
 
       if (status === BAD_REQUEST) {
-        console.log('Unauthorized');
-
         return;
       }
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -32,7 +32,7 @@ const useAuth = () => {
 
       return data;
     } catch (error) {
-      throw new Error('Error');
+      throw new Error('이메일 혹은 비밀번호를 잘못 입력했습니다.');
     }
   };
 


### PR DESCRIPTION
## 구현 내용
로그인 실패 시 사용자가 알림 토스트를 볼 수 있게 했습니다.

<!-- ## 스크린샷 -->

https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/99384699/538a2ad7-41a6-46f3-9706-458740cd7275

## 참고 사항<!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용 -->
- `useAuth`에서 `authServerCall`이 `data`를 `login`를 받을 경우 에러 처리를 하는 방향으로 하려다가 `authAuth` 에서는 최대한 다른 컴포넌트와 관련된 로직이 섞이는게 좋지 않아 보였습니다. 
- `loginForm`의 `handleSubmit` 함수내에서 error를 받아 토스트를 띄웠습니다. 
- 모달 위에 띄워 주기 위해 토스트 컨테이너에 `z-50`을 주었습니다. 

## 궁금한 점

## 이슈 번호

- close

<!--## 테스트 계획 또는 완료 사항-->
