### PR TITLE
feat: footer 태그 icon active 상태 코드 변경

### DIFF
--- a/src/components/domain/Footer/Footer.tsx
+++ b/src/components/domain/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { ChatIcon, HomeIcon, PencilIcon, PersonIcon } from '~/assets';
 import { LoginForm, Modal } from '~/components/common';
 import { useModal, useUser } from '~/hooks';
@@ -31,7 +31,6 @@ type LinkType = (typeof NavList)[number]['link'];
 
 const Footer = () => {
   const { pathname } = useLocation();
-  const navigate = useNavigate();
   const { modalOpened, openModal, closeModal } = useModal();
   const { user } = useUser();
   const initialNav =
@@ -47,8 +46,6 @@ const Footer = () => {
       : null;
 
   const [currentNav, setCurrentNav] = useState<LinkType | null>(initialNav);
-  const [selectedNav, setSelectedNav] = useState('/');
-  const [userId, setUserId] = useState(user ? user._id : '');
 
   useEffect(() => {
     if (pathname === '/' && currentNav !== '/') {
@@ -69,22 +66,6 @@ const Footer = () => {
     }
   }, [currentNav, pathname, user]);
 
-  useEffect(() => {
-    if (user && userId !== user._id) {
-      setUserId(user._id);
-    }
-  }, [user, userId]);
-
-  const handleCloseAfterLogin = () => {
-    closeModal();
-    navigate(selectedNav === '/profile' ? `/profile/${userId}` : selectedNav);
-  };
-
-  const handleOpenModal = (link: LinkType) => {
-    setSelectedNav(link);
-    openModal();
-  };
-
   return (
     <nav className="fixed bottom-0 z-10 flex h-24 w-screen max-w-[767px] border-t-2 bg-white pt-4">
       {NavList.map(({ Icon, text, link }) => (
@@ -92,11 +73,11 @@ const Footer = () => {
           {text !== '홈' && !user ? (
             <>
               <Modal modalOpened={modalOpened} handleClose={closeModal}>
-                <LoginForm handleClose={handleCloseAfterLogin} />
+                <LoginForm handleClose={closeModal} />
               </Modal>
               <button
                 className="flex w-20 flex-col items-center border-none bg-white sm:w-24"
-                onClick={() => handleOpenModal(link)}
+                onClick={openModal}
               >
                 <Icon />
                 <p className="mt-1 text-xs text-gray-600">{text}</p>


### PR DESCRIPTION
## 구현 내용

footer 태그에 추가적인 기능을 추가했습니다.
분기처리가 많아서 코드가 더러워보이네요...
아래의 useEffect 부분은 브라우저에서 뒤로가기 버튼 클릭 시 footer의 icon active 상태를 변경시키기 위해 사용했습니다.

```
useEffect(() => {
    if (pathname === '/' && currentNav !== '/') {
      setCurrentNav('/');
    } else if (
      pathname === '/conversations' &&
      currentNav !== '/conversations'
    ) {
      setCurrentNav('/conversations');
    } else if (
      user &&
      (pathname === `/profile/${user._id}` ||
        pathname === '/profile-edit' ||
        pathname === '/like-list' ||
        pathname === '/follow')
    ) {
      setCurrentNav('/profile');
    }
  }, [currentNav, pathname, user]);
```

## 이슈 번호

- close #223

<!--## 테스트 계획 또는 완료 사항-->
