### PR TITLE
postcard 컴포넌트 이미지 비율 조정

### DIFF
--- a/src/components/domain/PostCard/PostCard.tsx
+++ b/src/components/domain/PostCard/PostCard.tsx
@@ -26,7 +26,7 @@ const PostCard = ({
     <li>
       <button
         onClick={handleClick}
-        className="relative h-28 w-full rounded-lg border-2 border-gray-200"
+        className="relative aspect-[10/7] w-full rounded-lg border-2 border-gray-200"
       >
         <Image
           src={


### PR DESCRIPTION
## 구현 내용
pc 화면에서 나오던 이미지 비율을 조정했습니다. 피그마를 참고하여 10/7 비율로 설정했습니다.
## 스크린샷
![image](https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/86753969/c4feb4da-4a8d-4bcc-b95c-621e95cd755d)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/86753969/8d422972-6fa4-4aac-9d1c-75789587382d)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/86753969/a12ddc0c-fdac-4af9-bb3c-0ec7bc8e7584)
## 이슈 번호

- close #231 

<!--## 테스트 계획 또는 완료 사항-->
