### PR TITLE
게시글 페이지 리팩토링

### DIFF
--- a/src/pages/PostEditPage/PostEditPage.tsx
+++ b/src/pages/PostEditPage/PostEditPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import { ChannelList } from '../PostCreatePage';
 import { ImageIcon } from '~/assets';
@@ -19,6 +19,7 @@ import assert from '~/utils/assert';
 
 const PostEditPage = () => {
   const { state: pagePostId = '' } = useLocation();
+
   const { data: post } = useGetPost(pagePostId);
 
   assert(post);

--- a/src/pages/PostPage/PostPage.tsx
+++ b/src/pages/PostPage/PostPage.tsx
@@ -83,7 +83,24 @@ const PostPage = () => {
 
     const like = post.likes.find((like) => like.user === user?._id);
 
-    like ? unLikePost(like._id) : likePost(post._id);
+    if (like) {
+      unLikePost(like._id);
+
+      return;
+    }
+
+    likePost(postId ?? '', {
+      onSuccess: ({ data }) => {
+        if (data.user === post.author._id) return;
+
+        createNotification({
+          notificationType: 'LIKE',
+          notificationTypeId: data._id,
+          userId: post.author._id,
+          postId
+        });
+      }
+    });
   };
 
   const handleDeletePost = () => {

--- a/src/pages/PostPage/PostPage.tsx
+++ b/src/pages/PostPage/PostPage.tsx
@@ -12,6 +12,7 @@ import {
   useCreateNotification,
   useDeletePost
 } from '~/services';
+import { Comment } from '~/types';
 import assert from '~/utils/assert';
 
 const PostPage = () => {
@@ -54,7 +55,9 @@ const PostPage = () => {
       createComment(
         { comment, postId },
         {
-          onSuccess: ({ data }) => {
+          onSuccess: ({ data }: { data: Comment }) => {
+            if (data.author._id === post.author._id) return;
+
             createNotification({
               notificationType: 'COMMENT',
               notificationTypeId: data._id,

--- a/src/pages/PostPage/PostPage.tsx
+++ b/src/pages/PostPage/PostPage.tsx
@@ -44,10 +44,11 @@ const PostPage = () => {
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    if (!postId) return;
-    if (!textareaRef.current) return;
+    if (!postId || !textareaRef.current) return;
 
     event.preventDefault();
+
+    if (!user) return;
 
     try {
       createComment(

--- a/src/pages/PostPage/PostPage.tsx
+++ b/src/pages/PostPage/PostPage.tsx
@@ -40,7 +40,7 @@ const PostPage = () => {
   };
 
   const handleGoToEditPage = () => {
-    navigate(`/post-edit/${post._id}`);
+    navigate('/post-edit', { state: postId });
   };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -72,6 +72,12 @@ const PostPage = () => {
   };
 
   const handleLike = () => {
+    if (!user) {
+      openModal();
+
+      return;
+    }
+
     const like = post.likes.find((like) => like.user === user?._id);
 
     like ? unLikePost(like._id) : likePost(post._id);


### PR DESCRIPTION
## 구현 내용

게시글 페이지 리팩토링을 했습니다.

<!-- ## 스크린샷 -->

- 비회원 '로그인' 버튼 클릭 시 create comment api 호출 제어
- '게시글 수정' 메뉴 버튼 클릭 시 state 전송
- 내가 쓴 댓글 알림 보내지 않도록 막기
- 좋아요 클릭 시 알림 전송 기능 구현

## 이슈 번호

- close #236 

<!--## 테스트 계획 또는 완료 사항-->
