### PR TITLE
다크모드 적용 및 프로필페이지 버그 해결

### DIFF
--- a/src/components/domain/Header/Header.tsx
+++ b/src/components/domain/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import useDarkMode from './useDarkMode';
 import { BellIcon, LeftArrowIcon, SearchIcon } from '~/assets';
 import { Badge, Button } from '~/components/common';
 import { useUser, useUserNotifications } from '~/hooks';
@@ -18,6 +19,7 @@ const Header = memo(
     const navigate = useNavigate();
     const notification = useUserNotifications();
     const { user } = useUser();
+    const [darkMode, toggleDarkMode] = useDarkMode();
 
     const newNotification = notification.filter((item) => !item.seen);
 
@@ -42,6 +44,9 @@ const Header = memo(
         )}
         {rightArea && (
           <div className="absolute right-6 top-[3.75rem] flex gap-4">
+            <button onClick={toggleDarkMode}>
+              {darkMode ? 'light' : 'dark'}
+            </button>
             <Link to="/search">
               <SearchIcon className="h-6 w-6 stroke-white" />
             </Link>

--- a/src/components/domain/Header/useDarkMode.ts
+++ b/src/components/domain/Header/useDarkMode.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useDarkMode = (): [boolean, () => void] => {
+  const [darkMode, setDarkMode] = useState(false);
+
+  const toggleDarkMode = useCallback(() => {
+    if (darkMode) {
+      localStorage.setItem('theme', 'light');
+      document.documentElement.classList.remove('dark');
+      setDarkMode(false);
+    } else {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+      setDarkMode(true);
+    }
+  }, [darkMode]);
+
+  useEffect(() => {
+    if (
+      localStorage.theme === 'dark' ||
+      (!('theme' in localStorage) &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches)
+    ) {
+      setDarkMode(true);
+      document.documentElement.classList.add('dark');
+    } else {
+      setDarkMode(false);
+      document.documentElement.classList.remove('dark');
+    }
+  }, []);
+
+  return [darkMode, toggleDarkMode];
+};
+
+export default useDarkMode;

--- a/src/pages/ProfilePage/ProfileHeader.tsx
+++ b/src/pages/ProfilePage/ProfileHeader.tsx
@@ -76,15 +76,17 @@ const ProfileHeader = ({
   };
 
   const handleCreateFollow = () => {
-    createFollow(_id, {
-      onSuccess: ({ data }) => {
-        createNotification({
-          notificationType: 'FOLLOW',
-          notificationTypeId: data._id,
-          userId: _id
-        });
-      }
-    });
+    user
+      ? createFollow(_id, {
+          onSuccess: ({ data }) => {
+            createNotification({
+              notificationType: 'FOLLOW',
+              notificationTypeId: data._id,
+              userId: _id
+            });
+          }
+        })
+      : openModal();
   };
 
   const handleDeleteFollow = () => {

--- a/src/pages/ProfilePage/ProfileHeader.tsx
+++ b/src/pages/ProfilePage/ProfileHeader.tsx
@@ -103,7 +103,7 @@ const ProfileHeader = ({
   };
 
   return (
-    <div className="border-b-2 border-gray-200 bg-white px-6 py-10">
+    <div className="border-b-2 border-gray-200 bg-white px-6 py-10 dark:bg-slate-600">
       <Modal modalOpened={modalOpened} handleClose={closeModal}>
         <LoginForm handleClose={closeModal} />
       </Modal>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ import plugin from 'tailwindcss/plugin';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## 구현 내용

- [x] 프로필 페이지에서 비로그인 상태시 팔로우 버튼이 눌리는 문제를 해결했습니다.
- [x] tailwindcss에서 다크모드를 적용했습니다.

### 다크모드 관련 내용

[tailwindcss darkMode](https://tailwindcss.com/docs/dark-mode#customizing-the-class-name)

다크모드 수동 적용을 위해 아래의 코드를 추가했습니다.
```
// tailwind.config.js
export default {
  darkMode: 'class', // 다크모드 수동 적용 코드
  ....
}
```

그럼 다음 Header 폴더의 useDarMode.ts에서 `document.documentElement.classList.add`와 `localStorege.setItem`을 사용해서 다크모드가 수동 적용이 가능하게 했습니다.

localstorage로 사용자가 설정한 모드를 기억해서 페이지 새로고침 시에도 적용이 가능하게 했고 다크모드 설정 버튼을 한번도 누르지 않은 처음 사용자는 브라우저 다크모드 설정에 따라 변경되도록 했습니다.

컴포넌트들에서 다크모드에 따라 색상 변경을 하고 싶다면 아래의 코드와 같이 적용하면 될 것 같습니다.

```
<div className="bg-white dark:bg-slate-600" />
```

https://github.com/prgrms-fe-devcourse/FEDC4_HONKOK_JunilHwang/assets/45515388/6b44c21f-3331-4f4f-a0af-2ba3cb39ce84

## 이슈 번호

- close #260 

<!--## 테스트 계획 또는 완료 사항-->
