### PR TITLE
비밀번호 변경 후 홈페이지로 이동 처리

### DIFF
--- a/src/pages/ProfileEditPage/components/ProfilePassword.tsx
+++ b/src/pages/ProfileEditPage/components/ProfilePassword.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ProfileEditInput from './ProfileEditInput';
 import ProfileEditLabel from './ProfileEditLabel';
 import ProfileEditWrapper from './ProfileEditWrapper';
@@ -14,10 +15,12 @@ const ProfilePassword = () => {
   const { addToast } = useToast();
   const [showPassword, setShowPassword] = useState(false);
   const { modalOpened, openModal, closeModal } = useModal();
+  const navigate = useNavigate();
 
   const handleEditPassword = async () => {
     editPassword(password);
     closeModal();
+    navigate('/');
   };
 
   const handelButtonClick = () => {

--- a/src/pages/ProfileEditPage/components/ProfilePassword.tsx
+++ b/src/pages/ProfileEditPage/components/ProfilePassword.tsx
@@ -1,26 +1,32 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import ProfileEditInput from './ProfileEditInput';
 import ProfileEditLabel from './ProfileEditLabel';
 import ProfileEditWrapper from './ProfileEditWrapper';
 import { EyeOffIcon, EyeOnIcon } from '~/assets';
 import { Button, CheckForm, Modal, useToast } from '~/components/common';
-import { useForm, useModal } from '~/hooks';
+import { useModal } from '~/hooks';
 import { useEditPassword } from '~/services';
 import { isValidPassword } from '~/utils';
 
 const ProfilePassword = () => {
-  const [password, handlePassword] = useForm();
+  const [password, setPassword] = useState('');
   const { mutate: editPassword } = useEditPassword();
   const { addToast } = useToast();
   const [showPassword, setShowPassword] = useState(false);
   const { modalOpened, openModal, closeModal } = useModal();
-  const navigate = useNavigate();
+
+  const handlePassword = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+  };
+
+  const onSuccessEditPassword = () => {
+    setPassword('');
+    addToast({ content: '비밀번호가 변경되었습니다!' });
+  };
 
   const handleEditPassword = async () => {
-    editPassword(password);
+    editPassword(password, { onSuccess: onSuccessEditPassword });
     closeModal();
-    navigate('/');
   };
 
   const handelButtonClick = () => {


### PR DESCRIPTION
## 구현 내용

프로필 수정 페이지에서 비밀번호 변경 후 홈페이지로 이동처리 했습니다.
현재 비밀번호는 api로 받아올 수 있는 방법이 없어 바꿀 비빌번호가 현재 비밀번호와 동일한지 알 수 있는 방법이 없습니다. 따라서 비밀번호 변경이 성공한다면 홈페이지로 이동할 수 있는 처리를 했습니다.

## 이슈 번호

- close #279

<!--## 테스트 계획 또는 완료 사항-->
